### PR TITLE
IDE proposal: NSBP 2020

### DIFF
--- a/proposals/IDE/NSBP2020.md
+++ b/proposals/IDE/NSBP2020.md
@@ -1,0 +1,29 @@
+# Title
+Astropy Ambassadors at NSBP 2020
+
+## Summary
+The Astropy Project runs workshops and outreach efforts at meetings such as the American Astronomical Society meetings. It would be beneficial to the Project (in terms of growing a more diverse contributor and user base) to expand our reach to include meetings of other professional societies, especially prioritizing meetings that serve underrepresented minorities. One relevant professional society and conference is the National Society for Black Physicists (NSBP). As a first step toward a more concrete partnership with the NSBP, we propose to attend the NSBP 2020 as exhibitors.
+
+## Team
+- [Adrian Price-Whelan](https://github.com/adrn)
+- Anyone else who is interested to attend NSBP 2020! (**Please "suggest changes" to the Pull Request or leave a comment to be added**)
+
+## Plan
+We propose to register the Astropy Project as an academic exhibitor for the NSBP 2020 conference. An exhibitor registration comes with ([from the NSBP 2020 website](https://nsbp.org/exhibitors/2020-exhibitor-registration)):
+- Two (2) full conference registrations
+- Attendance to all Education and Scientific Sessions
+- Virtual Booth Available During Conference
+- Special designated exhibitor visitation during breaks
+- Leader Board Points for Attendees to your booth
+
+Adrian and one other Astropy Project representative will attend as exhibitors. We will prepare a ~10 minute introduction to Astropy to present at the virtual booth, and encourage conference attendees to come chat and ask questions about open source software and Astropy. Other Astropy Project attendees will attend education sessions and establish contact with NSBP conference leads.
+
+The registration deadline is October 23, 2020.
+
+## Impact
+The NSBP is the largest professional society specifically aimed at supporting efforts to increase opportunities for and empowering Black physicists. Partnering with the NSBP would create myriad new opportunities to begin to tackle improving the representation of Black contributors, leaders, and users within the Astropy community. Our initial primary aims are (1) to improve visibility of the Astropy Project within the NSBP, (2) provide an avenue to start discussing ways to better connect Astropy to the NSBP, and (3) explore whether it would be useful to propose to lead software training or Astropy-focused workshops at future NSBP meetings. We envision attending the NSBP as a first step towards future, concrete partnerships with the NSBP.
+
+## Budget
+Total amount requested: $1000 + TBD individual registrations ($130 each)
+
+This budget will be spent on conference registration fees.


### PR DESCRIPTION
# Title
Astropy Ambassadors at NSBP 2020

## Summary
The Astropy Project runs workshops and outreach efforts at meetings such as the American Astronomical Society meetings. It would be beneficial to the Project (in terms of growing a more diverse contributor and user base) to expand our reach to include meetings of other professional societies, especially prioritizing meetings that serve underrepresented minorities. One relevant professional society and conference is the National Society for Black Physicists (NSBP). As a first step toward a more concrete partnership with the NSBP, we propose to attend the NSBP 2020 as exhibitors.