### PR TITLE
Connect students with software interested mentors from the Astropy project

### DIFF
--- a/proposals/DEI/longtermmentor.md
+++ b/proposals/DEI/longtermmentor.md
@@ -1,0 +1,23 @@
+# Title
+Connect students with software interested mentors from the Astropy project
+
+## Summary 
+We should offer a way for students / Post-Docs ("students" in the following) to connect with Astropy developers for long-term (months) collaboration. The goal would be to match up peope with mutual scientific and technical interests for a science collaboration and use mentorship to guide the student to use and contribute back to FOSS, in particular astropy. 
+
+## Team 
+Moritz Guenther (@hamogu) - note that childcare needs mean that personally I cannot mentor anyone before the pandemic is over
+
+## Plan
+- Find 5-10 people in the Astropy project who are seriously interested in acting as mentors for (Astropy) software heavy science projects.
+- Offer (on the support and teams pages) a way to communicate with that group (slack channel, email). I envision that students would initiate a short dicussion on their project, asking for some initial advice. That could be answered by pointing to the astropy docs for simple questions, advice on which package to use (similar to how many questions in the facebook group are answered), or could develop into a true, long-term science collaboration. In the later case, the details of that project are out of Astropy's control, but I hope that a byproduct of those collaborations are support for a broader community of astronomers and contributions to Astropy.
+- Advertize the offer beyond astropy (e.g. through the IAU IOD)
+
+## Impact
+Undergrad and grad students often find mentors and collaborators through their advisers networks. Particularly in places where Astropy is underrrepresented, it's unlikely that advisors steer their students to seek out collaboration and mentorship with Astropy Developers, so this might give Astropy an inroads into new institutions and countries.
+
+## Budget
+This can be done as a "no-cost" science collaboration, but some aspects that could be supported with funding are:
+
+- tavel support for mentor and student to meet
+- stipend for student for some astropy-specific aspect of the work, e.g. converting part of their science code into PR or into a "learn astropy" tutorial?
+- stipend for mentor to increase motivation?


### PR DESCRIPTION
# Title
Connect students with software interested mentors from the Astropy project

## Summary 
We should offer a way for students / Post-Docs to connect with Astropy developers for long-term (months) collaboration. The goal would be to match up people with mutual scientific and technical interests for a science collaboration and use mentorship to guide the student to use and contribute back to FOSS, in particular astropy. 
