### PR TITLE
Draft a policy on email lists and slack channels

### DIFF
--- a/policies/communication_channels.md
+++ b/policies/communication_channels.md
@@ -56,7 +56,7 @@ Anyone can join the astropy slack workspace and join any number of channels, unl
 
 - gsoc-mentors: Same restriction as analogous mailing list
 
-Posting to all channels is open to call workspace members and shall
+Posting to all channels is open to all workspace members and shall
 not be restricted. The coordination committee can implement a "cool
 down" period following the same rules as established for email lists
 above.

--- a/policies/communication_channels.md
+++ b/policies/communication_channels.md
@@ -1,0 +1,62 @@
+# Communication channels in the Astropy Project
+
+## Preface
+
+Communication in the Astropy Project is governed by the [Community
+Code of Conduct](https://www.astropy.org/code_of_conduct.html), which
+takes precedence to anything written here. This goal of this policy is
+to write down some of the technicalities of how email lists, slack
+channels, forums etc. are set up.
+
+While Astropy aims to be an inclusive and welcoming community, we
+recognize that not all users want to be involved in the technical
+details of building and running a library like astropy, thus there are
+communication channels that are more geared towards users and others
+to developers. Also, in a project this size, certain issues that
+arise require privacy (e.g. personal or financial information is
+legally protected in many contries). Thus, there are communication
+channels geared towards or exclusively for developers, maintainers, or
+members of certain committees.
+
+
+## email communication geared towards project members
+
+The following mailing lists are maintained as Google groups. Unless
+specifically restricted, anyone worldwide can subscribe to the
+following lists and previous posts are publically avilable. List
+membership is required to post messages to prevent spam.
+
+- astropy-dev
+- astropy-affiliated-maintainers 
+- astropy-core-maintainer: Membership: Anyone with commit rights to the github/astropy/astropy repository
+- astropy-gsoc-mentors-XXX: Membership: Mentors of Astropy GSOC projects and astropy GSOC coordinator, coordination committee
+
+In order to be as open as possible, none of the aforelisted Google
+groups shall be moderated or posts by group members be otherwise
+restricted. However, the coordination committee can implement a "cool
+down" period of no more than 48 h if the coordination committee deems
+this necessary to maintain a respectful and welcoming
+atmosphere. During this period, posting may be restricted
+(e.g. moderated) by the coordination committee. The beginning and end
+of such a period has to be announced by the coordination committee on
+the respective mailing list. The coordination committee shall not
+implement a "cool down" within a week of any scheduled Astropy vote
+unless in the most obvious cases of Code of Conduct violations.
+
+
+The following email lists / aliases are restricted to members of the respective committee and are not public:
+
+- coordinators@astropy.org
+- confidential@astropy.org (Ombudsperson)
+- finance@astropy.org
+
+
+## astropy slack channels
+Anyone can join the astropy slack workspace and join any number of channels, unless specifically restricted. The following channels are restricted:
+
+- gsoc-mentors: Same restriction as analogous mailing list
+
+Posting to all channels is open to call workspace members and shall
+not be restricted. The coordination committee can implement a "cool
+down" period following the same rules as established for email lists
+above.

--- a/policies/communication_channels.md
+++ b/policies/communication_channels.md
@@ -21,34 +21,31 @@ members of certain committees.
 
 ## Email communication geared towards project members
 
-The following mailing lists are maintained as Google groups. Unless
-specifically restricted, anyone worldwide can subscribe to these lists,
-and previous posts are publicly available. List
-membership is required to post messages to prevent spam.
+Mailing lists are maintained as Google groups or through other list
+servers. Unless specifically restricted, anyone worldwide can
+subscribe to these lists, and previous posts are publicly
+available. List membership is required to post messages to prevent
+spam.  In order to be as open as possible, none of these lists shall
+be moderated and nor will posts by group members be otherwise
+restricted. However, the Coordination Committee can implement a "cool
+down" period of no more than 48 hours if they deem it necessary to
+maintain a respectful and welcoming atmosphere. During this period,
+posting may be moderated or otherwise restricted by the Coordination
+Committee. The beginning and end of such a period has to be announced
+by the Coordination Committee on the affected mailing list. The
+Coordination Committee shall not implement a "cool down" within a week
+of any scheduled Astropy vote unless in the most obvious cases of Code
+of Conduct violations.
 
-- astropy-dev
-- astropy-affiliated-maintainers 
+
+The following email lists / aliases are restricted in memebership and
+their content is not public:
+
 - astropy-core-maintainer: Membership: Anyone with commit rights to the github/astropy/astropy repository
 - astropy-gsoc-mentors-XXX: Membership: Mentors of Astropy GSOC projects and astropy GSOC coordinator, coordination committee
-
-In order to be as open as possible, none of these lists
-shall be moderated and nor will posts by group members be otherwise
-restricted. However, the Coordination Committee can implement a "cool
-down" period of no more than 48 hours if they deem
-it necessary to maintain a respectful and welcoming
-atmosphere. During this period, posting may be moderated or otherwise restricted
-by the Coordination Committee. The beginning and end
-of such a period has to be announced by the Coordination Committee on
-the affected mailing list. The Coordination Committee shall not
-implement a "cool down" within a week of any scheduled Astropy vote
-unless in the most obvious cases of Code of Conduct violations.
-
-
-The following email lists / aliases are restricted to members of the respective committee and are not public:
-
 - coordinators@astropy.org: Coordination Committee
 - confidential@astropy.org: Ombudsperson
-- finance@astropy.org: Interim Finance Committee
+- finance@astropy.org: Finance Committee
 
 
 ## Astropy Slack channels

--- a/policies/communication_channels.md
+++ b/policies/communication_channels.md
@@ -49,6 +49,7 @@ their content is not public:
 
 
 ## Astropy Slack channels
+
 Anyone can join the Astropy Slack workspace and join any number of channels, unless specifically restricted. The following channels are restricted:
 
 - gsoc-mentors: Same restriction as analogous mailing list

--- a/policies/communication_channels.md
+++ b/policies/communication_channels.md
@@ -14,7 +14,7 @@ details of building and running a library like Astropy. Therefore, some
 communication channels that are more geared towards users and others
 to developers. Also, in a project this size, certain issues that
 arise require privacy (e.g. personal or financial information is
-legally protected in many contries). Thus, there are communication
+legally protected in many countries). Thus, there are communication
 channels geared towards or exclusively for developers, maintainers, or
 members of certain committees.
 

--- a/policies/communication_channels.md
+++ b/policies/communication_channels.md
@@ -11,31 +11,31 @@ channels, forums etc. are set up.
 While we aim to be an inclusive and welcoming community, we
 recognize that not all users want to be involved in the technical
 details of building and running a library like Astropy. Therefore, some
-communication channels that are more geared towards users and others
+communication channels are more geared towards users and others
 to developers. Also, in a project this size, certain issues that
 arise require privacy (e.g. personal or financial information is
 legally protected in many countries). Thus, there are communication
 channels geared towards or exclusively for developers, maintainers, or
-members of certain committees.
+members of certain committees/roles.
 
 
 ## Email communication geared towards project members
 
 Mailing lists are maintained as Google groups or through other list
 servers.  Two examples of such lists are astropy@python.org, geared
-towards users, and astropy-dev@..., which is intended for more
+towards users, and [astropy-dev](http://groups.google.com/group/astropy-dev), which is intended for more
 technical developer discussions.  Unless specifically restricted,
 anyone worldwide can subscribe to these lists, and previous posts are
 publicly available. List membership is required to post messages to
 prevent spam.  In order to be as open as possible, none of these lists
-shall be moderated and nor will posts by group members be otherwise
+shall be moderated, nor will posts by group members be otherwise
 restricted. However, the Coordination Committee or the ombdbusperson
 can implement a "cool down" period of no more than 48 hours if they
 deem it necessary to maintain a respectful and welcoming
 atmosphere. During this period, posting may be moderated or otherwise
-restricted by the Coordination Committee or their designee. The
+restricted by the Coordination Committee, Ombudsperson, or their designee. The
 beginning and end of such a period has to be announced by the
-Coordination Committee on the affected mailing list. The Coordination
+Coordination Committee or Ombudsperson on the affected mailing list. The Coordination
 Committee shall not implement a "cool down" within a week of any
 scheduled Astropy vote unless in the most obvious cases of Code of
 Conduct violations.
@@ -45,11 +45,11 @@ The following email lists / aliases are restricted in membership and
 their content is not public:
 
 - astropy-core-maintainers: Membership: Anyone with commit rights to the github/astropy/astropy repository
-- astropy-gsoc-mentors-XXX: Membership: Mentors of Astropy GSOC projects and astropy GSOC coordinator, coordination committee
 - coordinators@astropy.org: Coordination Committee
 - confidential@astropy.org: Ombudsperson
 - finance@astropy.org: Finance Committee
 
+Other similar lists may be created as the Project requires them, but only with specific purposes in mind, as in general communication should be as open as possible.
 
 ## Astropy Slack team
 
@@ -58,6 +58,6 @@ channels, unless specifically restricted (following the same rules as
 restricted email lists).      
 
 Posting to all public channels is open to all workspace members and shall
-not be restricted. The Coordination Committee can implement a "cool
+not be restricted. The Coordination Committee or Ombudsperson can implement a "cool
 down" period following the same rules as established for email lists
 above.

--- a/policies/communication_channels.md
+++ b/policies/communication_channels.md
@@ -41,7 +41,7 @@ of Conduct violations.
 The following email lists / aliases are restricted in memebership and
 their content is not public:
 
-- astropy-core-maintainer: Membership: Anyone with commit rights to the github/astropy/astropy repository
+- astropy-core-maintainers: Membership: Anyone with commit rights to the github/astropy/astropy repository
 - astropy-gsoc-mentors-XXX: Membership: Mentors of Astropy GSOC projects and astropy GSOC coordinator, coordination committee
 - coordinators@astropy.org: Coordination Committee
 - confidential@astropy.org: Ombudsperson

--- a/policies/communication_channels.md
+++ b/policies/communication_channels.md
@@ -4,13 +4,13 @@
 
 Communication in the Astropy Project is governed by the [Community
 Code of Conduct](https://www.astropy.org/code_of_conduct.html), which
-takes precedence to anything written here. This goal of this policy is
-to write down some of the technicalities of how email lists, slack
+takes precedence over anything written here. This goal of this policy is
+to write down the technical details of how email lists, Slack
 channels, forums etc. are set up.
 
-While Astropy aims to be an inclusive and welcoming community, we
+While we aim to be an inclusive and welcoming community, we
 recognize that not all users want to be involved in the technical
-details of building and running a library like astropy, thus there are
+details of building and running a library like Astropy. Therefore, some
 communication channels that are more geared towards users and others
 to developers. Also, in a project this size, certain issues that
 arise require privacy (e.g. personal or financial information is
@@ -19,11 +19,11 @@ channels geared towards or exclusively for developers, maintainers, or
 members of certain committees.
 
 
-## email communication geared towards project members
+## Email communication geared towards project members
 
 The following mailing lists are maintained as Google groups. Unless
-specifically restricted, anyone worldwide can subscribe to the
-following lists and previous posts are publically avilable. List
+specifically restricted, anyone worldwide can subscribe to these lists,
+and previous posts are publicly available. List
 membership is required to post messages to prevent spam.
 
 - astropy-dev
@@ -31,32 +31,32 @@ membership is required to post messages to prevent spam.
 - astropy-core-maintainer: Membership: Anyone with commit rights to the github/astropy/astropy repository
 - astropy-gsoc-mentors-XXX: Membership: Mentors of Astropy GSOC projects and astropy GSOC coordinator, coordination committee
 
-In order to be as open as possible, none of the aforelisted Google
-groups shall be moderated or posts by group members be otherwise
-restricted. However, the coordination committee can implement a "cool
-down" period of no more than 48 h if the coordination committee deems
-this necessary to maintain a respectful and welcoming
-atmosphere. During this period, posting may be restricted
-(e.g. moderated) by the coordination committee. The beginning and end
-of such a period has to be announced by the coordination committee on
-the respective mailing list. The coordination committee shall not
+In order to be as open as possible, none of these lists
+shall be moderated and nor will posts by group members be otherwise
+restricted. However, the Coordination Committee can implement a "cool
+down" period of no more than 48 hours if they deem
+it necessary to maintain a respectful and welcoming
+atmosphere. During this period, posting may be moderated or otherwise restricted
+by the Coordination Committee. The beginning and end
+of such a period has to be announced by the Coordination Committee on
+the affected mailing list. The Coordination Committee shall not
 implement a "cool down" within a week of any scheduled Astropy vote
 unless in the most obvious cases of Code of Conduct violations.
 
 
 The following email lists / aliases are restricted to members of the respective committee and are not public:
 
-- coordinators@astropy.org
-- confidential@astropy.org (Ombudsperson)
-- finance@astropy.org
+- coordinators@astropy.org: Coordination Committee
+- confidential@astropy.org: Ombudsperson
+- finance@astropy.org: Interim Finance Committee
 
 
-## astropy slack channels
-Anyone can join the astropy slack workspace and join any number of channels, unless specifically restricted. The following channels are restricted:
+## Astropy Slack channels
+Anyone can join the Astropy Slack workspace and join any number of channels, unless specifically restricted. The following channels are restricted:
 
 - gsoc-mentors: Same restriction as analogous mailing list
 
 Posting to all channels is open to all workspace members and shall
-not be restricted. The coordination committee can implement a "cool
+not be restricted. The Coordination Committee can implement a "cool
 down" period following the same rules as established for email lists
 above.

--- a/policies/communication_channels.md
+++ b/policies/communication_channels.md
@@ -31,7 +31,7 @@ restricted. However, the Coordination Committee can implement a "cool
 down" period of no more than 48 hours if they deem it necessary to
 maintain a respectful and welcoming atmosphere. During this period,
 posting may be moderated or otherwise restricted by the Coordination
-Committee. The beginning and end of such a period has to be announced
+Committee or their designee. The beginning and end of such a period has to be announced
 by the Coordination Committee on the affected mailing list. The
 Coordination Committee shall not implement a "cool down" within a week
 of any scheduled Astropy vote unless in the most obvious cases of Code

--- a/policies/communication_channels.md
+++ b/policies/communication_channels.md
@@ -22,23 +22,26 @@ members of certain committees.
 ## Email communication geared towards project members
 
 Mailing lists are maintained as Google groups or through other list
-servers. Unless specifically restricted, anyone worldwide can
-subscribe to these lists, and previous posts are publicly
-available. List membership is required to post messages to prevent
-spam.  In order to be as open as possible, none of these lists shall
-be moderated and nor will posts by group members be otherwise
-restricted. However, the Coordination Committee can implement a "cool
-down" period of no more than 48 hours if they deem it necessary to
-maintain a respectful and welcoming atmosphere. During this period,
-posting may be moderated or otherwise restricted by the Coordination
-Committee or their designee. The beginning and end of such a period has to be announced
-by the Coordination Committee on the affected mailing list. The
-Coordination Committee shall not implement a "cool down" within a week
-of any scheduled Astropy vote unless in the most obvious cases of Code
-of Conduct violations.
+servers.  Two examples of such lists are astropy@python.org, geared
+towards users, and astropy-dev@..., which is intended for more
+technical developer discussions.  Unless specifically restricted,
+anyone worldwide can subscribe to these lists, and previous posts are
+publicly available. List membership is required to post messages to
+prevent spam.  In order to be as open as possible, none of these lists
+shall be moderated and nor will posts by group members be otherwise
+restricted. However, the Coordination Committee or the ombdbusperson
+can implement a "cool down" period of no more than 48 hours if they
+deem it necessary to maintain a respectful and welcoming
+atmosphere. During this period, posting may be moderated or otherwise
+restricted by the Coordination Committee or their designee. The
+beginning and end of such a period has to be announced by the
+Coordination Committee on the affected mailing list. The Coordination
+Committee shall not implement a "cool down" within a week of any
+scheduled Astropy vote unless in the most obvious cases of Code of
+Conduct violations.
 
 
-The following email lists / aliases are restricted in memebership and
+The following email lists / aliases are restricted in membership and
 their content is not public:
 
 - astropy-core-maintainers: Membership: Anyone with commit rights to the github/astropy/astropy repository
@@ -48,13 +51,13 @@ their content is not public:
 - finance@astropy.org: Finance Committee
 
 
-## Astropy Slack channels
+## Astropy Slack team
 
-Anyone can join the Astropy Slack workspace and join any number of channels, unless specifically restricted. The following channels are restricted:
+Anyone can join the Astropy Slack workspace and join any number of
+channels, unless specifically restricted (following the same rules as
+restricted email lists).      
 
-- gsoc-mentors: Same restriction as analogous mailing list
-
-Posting to all channels is open to all workspace members and shall
+Posting to all public channels is open to all workspace members and shall
 not be restricted. The Coordination Committee can implement a "cool
 down" period following the same rules as established for email lists
 above.


### PR DESCRIPTION
The goal of this policy is to write down how mailing lists (both public and restricted) are set up in astropy. Who gets to be a member? Is the content available openly? Are the lists moderated?

This is a WIP for several reasons:

- This not an "as-is" (e.g. I don't know if any of our mailing lists are currently moderated), but an "as I want it to be" that needds discussion and community consensus.
- I may not be aware of all communication channels used. Missing channels need to be added (with membership restriction as appropriate) - please add comments or PRs to my branch.

I think this is a policy that's way below the level of e.g. APE0, thus I think it's appropriate to suggest this as a PR in the project repository. Like an APE, it should probably annouced on astropy-dev, when the list of lists is more complete.

**Edit**: After review by a number of people and rewording to avoid the "missing channels still need to be added" problem mentions above, I've removed the WIP label.