### PR TITLE
Add general permissions policy document

### DIFF
--- a/messages/maintainer_access.md
+++ b/messages/maintainer_access.md
@@ -10,6 +10,7 @@ If you would like to accept this nomination, we ask that you familiarize yoursel
 * [Basic development workflow](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html)
 * [Guidelines on when to squash or rebase](https://docs.astropy.org/en/latest/development/when_to_rebase.html)
 * [Astropy Project Code of Conduct](https://www.astropy.org/code_of_conduct.html)
+* [GitHub two-factor authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)
 
 If you accept, please respond indicating that you've reviewed the developer documentation and that you have read and agree to abide by the Code of Conduct. After we receive that email from you, we will make an announcement and there will be a two week period of comment. After that period is over, your name will be added to the team webpage and you will be given the appropriate Github permissions.
 

--- a/policies/coordinated-write-permissions.md
+++ b/policies/coordinated-write-permissions.md
@@ -1,9 +1,0 @@
-# Write Permissions for Coordinated Package Repositories
-
-This policy describes the rules and expectations for receiving write permissions for Coordinated Packages (including the Astropy Core Package).
-
-Github write privileges are granted when someone is given a relevant named role. In most cases this is package (or sub-package) maintainer, although other roles (for example, the astropy.org web page maintainer) may also come with write permissions for a specific named repository.  Occasional *temporary* write (or higher) permissions may be granted for specific tasks (for example, a maintainer may be given admin rights to a repo to configure CI for the first time or similar), but such permissions must be done temporarily.
-
-Normal write permissions should be given by assigning sometime to the Github Team that corresponds to that role (For example, "Astropy Core Maintainers" or "Astropy web site maintainers" for a core maintainer or the astropy.org team, respectively), a duty primarily performed by the Coordination Committee.  Temporary permissions should instead use the "collaborator" feature on Github to make it clear that these permissions are temporary in nature.
-
-Additionally, the granter of permissions (usually the Coordination Committee) should send a message to the new recipient of write permissions the responsibilities and expectations that go with this - a template for this email is available [in this repo](../messages/core_write_access.md). That message may contain a prompt for a response, which should be cced/forwarded to coordinators@astropy.org

--- a/policies/permissions.md
+++ b/policies/permissions.md
@@ -1,22 +1,22 @@
-# Permissions across the project
+# Permissions across the Project
 
 This document describes what access permissions are granted to individuals in
 different [roles in the project](https://www.astropy.org/team.html#roles).
 
 Occasional *temporary* write (or higher) permissions may be granted for specific
 tasks (for example, a maintainer may be given admin rights to a repo to
-configure CI for the first time or similar), be such permissions must be done
-temporarily unless prescribed by this document.
+configure CI for the first time or similar). Such permissions must be done
+temporarily unless prescribed otherwise by this document.
 
-For GitHub, the permissions are enforced by adding indivuals to the GitHub team
-matching their role (For Example, "Astropy Core Maintainers" or "Astropy web
-site maintainers" for a core maintainer or the astropy.org team, respectively),
+For GitHub, the permissions are enforced by adding individuals to the GitHub team
+matching their role (for example, "Astropy Core Maintainers" or "Astropy
+website maintainers" for a core maintainer or the astropy.org team, respectively),
 a duty primarily performed at the moment by the Coordination Committee.
 Temporary permissions should instead use the "collaborator" feature on Github to
 make it clear that these permissions are temporary in nature.
 
 Additionally, the granter of permissions (usually the Coordination Committee)
-should send a message to the new recipient of write permissions the
+should send a message to the new recipient of write permissions listing the
 responsibilities and expectations that go with this - a template for this email
 is available [in this repo](../messages/core_write_access.md). That message may
 contain a prompt for a response, which should be cc-ed/forwarded to
@@ -30,7 +30,7 @@ repository via the **Astropy Core Maintainers** GitHub team.
 ## Coordinated package maintainers
 
 Coordinated package maintainers receive **admin access** to the coordinated
-package repositories via the **<package name> maintainers** GitHUb team (e.g.
+package repositories via the **<package name> maintainers** GitHUb team (e.g.,
 'astroquery maintainers').
 
 ## Core package release coordinators
@@ -43,6 +43,6 @@ release maintainers** GitHub team.
 
 ## Coordination committee
 
-The coordination committee members receive **owner access** to all repositories
-in the astropy organization. In addition, they have access to the project
-password manager.
+The coordination committee members receive **owner access** to
+the astropy organization. In addition, they have access to the project
+credentials (or the shared password manager to access the credentials).

--- a/policies/permissions.md
+++ b/policies/permissions.md
@@ -17,16 +17,12 @@ a duty primarily performed at the moment by the Coordination Committee.
 Temporary permissions should instead use the "collaborator" feature on Github to
 make it clear that these permissions are temporary in nature.
 
-Regardless of access level, even if it is temporary,
-[GitHub two-factor authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)
-must be enabled for the affect user accounts.
-
 Additionally, the granter of permissions (usually the Coordination Committee)
 should send a message to the new recipient of write permissions listing the
 responsibilities and expectations that go with this - a template for this email
 is available [in this repo](../messages/maintainer_access.md). That message may
 contain a prompt for a response, which should be cc-ed/forwarded to
-coordinators@astropy.org .
+`coordinators[at]astropy.org`.
 
 ## Access levels
 
@@ -40,6 +36,9 @@ repository via the **Astropy Core Maintainers** GitHub team.
 Coordinated package maintainers receive **admin access** to the coordinated
 package repositories via the **<package name> maintainers** GitHub team (e.g.,
 'astroquery maintainers').
+
+Lower priviledge access (e.g., write, triage) could be assigned to additional
+contributors as separate teams (e.g., 'Astroquery Triage').
 
 ### Core package release coordinators
 
@@ -74,7 +73,10 @@ which might not cover all cases, other ways include:
 
 ### Automated access
 
-(TODO: Fill in info from the automated invite bot that Matt Craig deployed.)
+We have an automated workflow to
+[invite organization members based on merged PRs](https://github.com/astropy/astropy-tools/actions/workflows/update_org_members.yml).
+However, we are open to suggestions on how to improve it
+over at [astropy-tools GitHub Issue 178](https://github.com/astropy/astropy-tools/issues/178).
 
 ### Manual request
 

--- a/policies/permissions.md
+++ b/policies/permissions.md
@@ -8,41 +8,93 @@ tasks (for example, a maintainer may be given admin rights to a repo to
 configure CI for the first time or similar). Such permissions must be done
 temporarily unless prescribed otherwise by this document.
 
-For GitHub, the permissions are enforced by adding individuals to the GitHub team
+For GitHub, the
+[permissions](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization)
+are enforced by adding individuals to the GitHub team
 matching their role (for example, "Astropy Core Maintainers" or "Astropy
 website maintainers" for a core maintainer or the astropy.org team, respectively),
 a duty primarily performed at the moment by the Coordination Committee.
 Temporary permissions should instead use the "collaborator" feature on Github to
 make it clear that these permissions are temporary in nature.
 
+Regardless of access level, even if it is temporary,
+[GitHub two-factor authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)
+must be enabled for the affect user accounts.
+
 Additionally, the granter of permissions (usually the Coordination Committee)
 should send a message to the new recipient of write permissions listing the
 responsibilities and expectations that go with this - a template for this email
-is available [in this repo](../messages/core_write_access.md). That message may
+is available [in this repo](../messages/maintainer_access.md). That message may
 contain a prompt for a response, which should be cc-ed/forwarded to
-coordinators@astropy.org
+coordinators@astropy.org .
 
-## Core package maintainers
+## Access levels
 
-All maintainers listed for the core package receive *write access** to the
+### Core package maintainers
+
+All maintainers listed for the core package receive *write access* to the
 repository via the **Astropy Core Maintainers** GitHub team.
 
-## Coordinated package maintainers
+### Coordinated package maintainers
 
 Coordinated package maintainers receive **admin access** to the coordinated
-package repositories via the **<package name> maintainers** GitHUb team (e.g.,
+package repositories via the **<package name> maintainers** GitHub team (e.g.,
 'astroquery maintainers').
 
-## Core package release coordinators
+### Core package release coordinators
 
 Core package release coordinators receive **admin access** to the core
-repository, as well as the astropy-helpers and extension-helpers repositories
-since releases of those packages may be tightly coupled to the core package, as
+repository, as well as the extension-helpers repository
+since releases of those packages may be tightly coupled, as
 well as **write access** to the website repository. This is done via the **Core
 release maintainers** GitHub team.
 
-## Coordination committee
+### Coordination committee
 
-The coordination committee members receive **owner access** to
-the astropy organization. In addition, they have access to the project
+The Coordination Committee members receive **owner access** to
+the astropy GitHub organization. Members who are not familiar or
+comfortable with GitHub administration may opt out. However,
+a majority of the committee should have access. If necessary,
+members should receive GitHub administration training before given access.
+
+In addition, they have access to the project
 credentials (or the shared password manager to access the credentials).
+As with GitHub access above, members may opt out but the majority and training
+rules also apply here.
+
+Regardless of access level, the members are always bound by
+[APE 0](https://github.com/astropy/astropy-APEs/blob/main/APE0.rst).
+For example, a Coordination Committee member cannot delete or transfer
+a repository without first obtaining concensus from the community.
+
+## Other ways to gain access
+
+Besides the process laid out a the beginning of this document,
+which might not cover all cases, other ways include:
+
+### Automated access
+
+(TODO: Fill in info from the automated invite bot that Matt Craig deployed.)
+
+### Manual request
+
+If for some reason there was an oversight in the process or a special
+situation that is not covered, people could request access
+(for themselves or others) using the
+[Astropy Github Organisation Administration](https://github.com/astropy/astropy-project/issues/new?assignees=&labels=github-admin&projects=&template=github-admin.yaml)
+issue template. Please clearly state the reason for the request.
+Once the issue is opened, one of the Coordination Committee members
+would handle it as appropriate.
+
+## Removing access
+
+As people switch roles or leave the project completely, GitHub access
+would be adjusted accordingly. For example, if a maintainer is no
+longer active and is not responsive to developer surveys,
+the Coordination Committee has the right to remove this person
+from a named role and thus the associated GitHub permission(s).
+This also applies to Coordination Commitee members that rotated off.
+
+Anyone that abuses their given priviledge will also have it removed.
+Please report any abuse to the Coordination Committee or the Ombudsperson,
+as you see fit.

--- a/policies/permissions.md
+++ b/policies/permissions.md
@@ -61,10 +61,11 @@ credentials (or the shared password manager to access the credentials).
 As with GitHub access above, members may opt out but the majority and training
 rules also apply here.
 
-Regardless of access level, the members are always bound by
+In general, the use of owner access requires permission of the rest of the Coordination
+Committee. Furthermore, regardless of access level, the members are always bound by
 [APE 0](https://github.com/astropy/astropy-APEs/blob/main/APE0.rst).
-For example, a Coordination Committee member cannot delete or transfer
-a repository without first obtaining concensus from the community.
+For example, the Coordination Committee, let alone just one of its members, cannot
+delete or transfer a repository without first obtaining consensus from the community.
 
 ## Other ways to gain access
 

--- a/policies/permissions.md
+++ b/policies/permissions.md
@@ -1,0 +1,48 @@
+# Permissions across the project
+
+This document describes what access permissions are granted to individuals in
+different [roles in the project](https://www.astropy.org/team.html#roles).
+
+Occasional *temporary* write (or higher) permissions may be granted for specific
+tasks (for example, a maintainer may be given admin rights to a repo to
+configure CI for the first time or similar), be such permissions must be done
+temporarily unless prescribed by this document.
+
+For GitHub, the permissions are enforced by adding indivuals to the GitHub team
+matching their role (For Example, "Astropy Core Maintainers" or "Astropy web
+site maintainers" for a core maintainer or the astropy.org team, respectively),
+a duty primarily performed at the moment by the Coordination Committee.
+Temporary permissions should instead use the "collaborator" feature on Github to
+make it clear that these permissions are temporary in nature.
+
+Additionally, the granter of permissions (usually the Coordination Committee)
+should send a message to the new recipient of write permissions the
+responsibilities and expectations that go with this - a template for this email
+is available [in this repo](../messages/core_write_access.md). That message may
+contain a prompt for a response, which should be cc-ed/forwarded to
+coordinators@astropy.org
+
+## Core package maintainers
+
+All maintainers listed for the core package receive *write access** to the
+repository via the **Astropy Core Maintainers** GitHub team.
+
+## Coordinated package maintainers
+
+Coordinated package maintainers receive **admin access** to the coordinated
+package repositories via the **<package name> maintainers** GitHUb team (e.g.
+'astroquery maintainers').
+
+## Core package release coordinators
+
+Core package release coordinators receive **admin access** to the core
+repository, as well as the astropy-helpers and extension-helpers repositories
+since releases of those packages may be tightly coupled to the core package, as
+well as **write access** to the website repository. This is done via the **Core
+release maintainers** GitHub team.
+
+## Coordination committee
+
+The coordination committee members receive **owner access** to all repositories
+in the astropy organization. In addition, they have access to the project
+password manager.


### PR DESCRIPTION
This is a continuation and generalization of #99. It is not in any way complete but shows how I think we might want to organize things to be more general than #99, and be more general than just GitHub. Once complete, this fixes #143.

For now this is very incomplete, but I can try and work on it more if people are generally on board with the idea. Let's also make this what we want not what is currently the case (e.g. in this version the release coordinators have admin access to repos, not write access)

cc @eteq as the author of #99 - we may want to just merge #99 as the 'current policy' as this present PR may take a few weeks to hash out fully.