### PR TITLE
How do we distribute money within the Astropy project?

### DIFF
--- a/finance/proposal-calls/internal_template.md
+++ b/finance/proposal-calls/internal_template.md
@@ -1,13 +1,13 @@
 # Phase II funding proposals
 
-*This is a draft document for how the Interim Finance Committee envisions the process of distributing grant money (e.g. from the Moore grant) within the Astropy project. This is a general template and the finance committee will change the details for individual calls. In particular, actual dollar numbers and details of the grant and grant rules that limit the work that could be proposed will need to be filled in. This template is written with the current Moore grant in mind.*
+*This is a draft document for how the Interim Finance Committee envisions the process of distributing grant money (e.g. from the Moore grant) within the Astropy project. This is a general template and the finance committee will change the details for individual calls. In particular, the actually available funding and details of the grant and grant rules that limit the work that could be proposed will need to be filled in. This template is written with the current Moore grant in mind.*
 
 ## Proposal goals
 Proposals shall improve the Astropy Project. This includes code for the core repository, for coordinated or affiliated packages, infrastructure (e.g. testing, CI), tutorials, workshops, notebooks, community engagement, inclusion, diversity and empowerment, and anything else broadly Project related. 
 
 Proposals shall foster the Astropy Project goals of community, shared work, and cooperation and shall be proposed and executed in this manner.
 
-Total funding for this call is coming from (**link to grant here**) and XXX $ are available in total over XX months. 
+Total funding for this call is coming from (**link to grant here**) and XXX $ are available in total in the period XXX to XXX.
 
 Proposals need to clearly identify what the funding is used for (e.g. "pay YYY $ to add Klingon Standard Time to astropy.time" or "organize astropy workshop to engage amateur astronomer community in Antarctica")
 
@@ -16,10 +16,10 @@ Proposals need to clearly identify what the funding is used for (e.g. "pay YYY $
 
 - Source of money (e.g. Moore grant)
 - Specific area of proposal (e.g. Astropy may have a grant that can be used only for a specific purpose, e.g. only for community outreach)
-- Restrictions: Depending on who provided the money to astropy, it’s use might be restricted, e.g. only to contractors in certain countries
+- Restrictions: Depending on who provided the money to astropy, its use might be restricted, e.g. only to contractors in certain countries
 
 ## Proposal process
-Proposals should be posted as pull requests to github.com/astropy/astropy-project/ with the initial title text "Phase II Proposal:".
+Proposals should be posted as pull requests to github.com/astropy/astropy-project/ with the initial title text "Funding Proposal XXX:".
 The goal is to make this process as easy as possible on everyone, so we impose a limit of 100 lines assuming 80 char/line. We provide a template below. 
 We envision a two stage proposal process to enable the community to comment and improve ideas, teams with similar ideas can merge to avoid duplicated work, etc...
 
@@ -33,11 +33,11 @@ We envision a two stage proposal process to enable the community to comment and 
 
 At the second  deadline, the text for the proposals is frozen but comments are still allowed. Within 7 days of this deadline, the Finance Committee will review all proposals to ensure they are compatible with the terms of the currently available funding sources and should be included in the proposals to be voted on.
 
-After that, voting members of the Astropy Project vote on the proposals. The vote is held online with a secret ballot. Every voting member of the Astropy Project (as defined in the governance documents) gets X votes they can assign to one or more proposals. After the vote, proposals are ranked according to the number of votes.
+After that, voting members of the Astropy Project vote on the proposals. The vote is held online with a secret ballot. Every voting member of the Astropy Project (as defined in the governance documents) has equal voting rights. 
 
 *Rationale: In this process every member's vote carries equal weight; the decision is made directly by the members. The ballot shall be secret to allow members to vote based on the merit of the proposal without fear of retribution.*
 
-*Note:* Other voting schemes can be considered. Alternatives are e.g. everyone picks their top 5, or everyone gets to vote up as many proposals as they like (but obviously, upvoting everything won’t make a difference). To make this process manageable, we need to find an external online platform that gives us the infrastructure for the voting process. If choices are limited, one of the alternatives voting schemes can be chosen, as long as the process is clearly communicated at the time of the call for proposals. If possible, the voting system will be the same as that used for astropy governance-related voting.
+*Note:* Fill in exact voting scheme here, e.g. every member selects up to five votes and proposals are ranked by number of votes. To make this process manageable, we need to find an external online platform that gives us the infrastructure for the voting process, which may limit the voting scheme we can choose from.
 
 The CoCo and the Finance Committee will select proposals following the ranking by the members and taking into account the requirements of the available grant funding (e.g. the Moore grant specifically has a budget for work on "spectroscopy". If none of the highest ranking proposals deals with spectroscopy, this money could  be awarded to the highest ranking spectroscopy proposal, even if that means that other, higher ranked proposals won't be executed).
 
@@ -51,6 +51,6 @@ Money can be used for travel, infrastructure, equipment etc, but in many cases, 
 
 In either case, the Finance Committee will take care of the formal process of setting up statements of work, signing contracts, and reviewing invoices. Other funding strategies that we have not anticipated will also be considered.
 
-Note: The Finance Committee realizes that this process may lead to a number of parallel, possibly competing searches by different groups of people. We expect all searches to follow the code of conduct with respect to fairness, non-discimination etc. Complaints to ombdus@astropy, If these procedures are violated, funding for that specific project will not be granted. Proposals planning to do a search should include the cost of job listings in their budget.
+Note: The Finance Committee realizes that this process may lead to a number of parallel, possibly competing searches by different groups of people. We expect all searches to follow the code of conduct with respect to fairness, non-discimination etc. Any violation should be brought the finance committee or the Astropy Ombudspersion (confidential@astropy.org). If these procedures are violated, funding for that specific project will not be granted. Proposals planning to do a search should include the cost of job listings in their budget.
 
 In the future, we would like to offer an opportunity to propose projects that the community likes with no names attached, but right now, the Finance Committee can not commit the necessary capacity to handle such a multi-step process. 

--- a/finance/proposal-calls/internal_template.md
+++ b/finance/proposal-calls/internal_template.md
@@ -1,0 +1,56 @@
+# Phase II funding proposals
+
+*This is a draft document for how the Interim Finance Committee envisions the process of distributing grant money (e.g. from the Moore grant) within the Astropy project. This is a general template and the finance committee will change the details for individual calls. In particular, actual dollar numbers and details of the grant and grant rules that limit the work that could be proposed will need to be filled in. This template is written with the current Moore grant in mind.*
+
+## Proposal goals
+Proposals shall improve the Astropy Project. This includes code for the core repository, for coordinated or affiliated packages, infrastructure (e.g. testing, CI), tutorials, workshops, notebooks, community engagement, inclusion, diversity and empowerment, and anything else broadly Project related. 
+
+Proposals shall foster the Astropy Project goals of community, shared work, and cooperation and shall be proposed and executed in this manner.
+
+Total funding for this call is coming from (**link to grant here**) and XXX $ are available in total over XX months. 
+
+Proposals need to clearly identify what the funding is used for (e.g. "pay YYY $ to add Klingon Standard Time to astropy.time" or "organize astropy workshop to engage amateur astronomer community in Antarctica")
+
+## Proposal details
+**Fill in here when using this template to issue an internal Astropy call**
+
+- Source of money (e.g. Moore grant)
+- Specific area of proposal (e.g. Astropy may have a grant that can be used only for a specific purpose, e.g. only for community outreach)
+- Restrictions: Depending on who provided the money to astropy, it’s use might be restricted, e.g. only to contractors in certain countries
+
+## Proposal process
+Proposals should be posted as pull requests to github.com/astropy/astropy-project/ with the initial title text "Phase II Proposal:".
+The goal is to make this process as easy as possible on everyone, so we impose a limit of 100 lines assuming 80 char/line. We provide a template below. 
+We envision a two stage proposal process to enable the community to comment and improve ideas, teams with similar ideas can merge to avoid duplicated work, etc...
+
+- Deadline 1: Draft Proposal Deadline (after this date, no new proposals)
+- Two week discussion period during which proposals can be modified
+- Deadline 2: Finalized Proposals are due
+- Finance Committee reviews for compatibility with legal conditions
+- Deadline 2 + 7 business days: voting begins.
+
+*Rationale: We aim to achieve community consensus before the vote. Proposers may combine ideas and teams or withdraw proposals during the discussion period.*
+
+At the second  deadline, the text for the proposals is frozen but comments are still allowed. Within 7 days of this deadline, the Finance Committee will review all proposals to ensure they are compatible with the terms of the currently available funding sources and should be included in the proposals to be voted on.
+
+After that, voting members of the Astropy Project vote on the proposals. The vote is held online with a secret ballot. Every voting member of the Astropy Project (as defined in the governance documents) gets X votes they can assign to one or more proposals. After the vote, proposals are ranked according to the number of votes.
+
+*Rationale: In this process every member's vote carries equal weight; the decision is made directly by the members. The ballot shall be secret to allow members to vote based on the merit of the proposal without fear of retribution.*
+
+*Note:* Other voting schemes can be considered. Alternatives are e.g. everyone picks their top 5, or everyone gets to vote up as many proposals as they like (but obviously, upvoting everything won’t make a difference). To make this process manageable, we need to find an external online platform that gives us the infrastructure for the voting process. If choices are limited, one of the alternatives voting schemes can be chosen, as long as the process is clearly communicated at the time of the call for proposals. If possible, the voting system will be the same as that used for astropy governance-related voting.
+
+The CoCo and the Finance Committee will select proposals following the ranking by the members and taking into account the requirements of the available grant funding (e.g. the Moore grant specifically has a budget for work on "spectroscopy". If none of the highest ranking proposals deals with spectroscopy, this money could  be awarded to the highest ranking spectroscopy proposal, even if that means that other, higher ranked proposals won't be executed).
+
+*Rationale: This is similar to how e.g. ESO or HST proposals as awarded. Technically, the TACs suggest a list of proposals for the director, who is free to pick in any way they like. However, the TAC ranking is followed unless there are strong reasons against it (e.g. a scheduling requirement cannot be accommodated). This process is well accepted in the community and thus it makes sense to follow it here.*
+
+## Who will be paid to do work?
+Money can be used for travel, infrastructure, equipment etc, but in many cases, money will be used to pay people to do work for Astropy. In that case, the following approaches can be used:
+
+- Proposals can list one or more people who will perform the work and any needed budget to support the work.
+- The proposers can alternatively not commit to the work themselves, but promise to organize a job search, accept applications, and select a candidate within 6 months of the proposal being accepted. Contact details of the selected person are then forward to the Finance Committee. The proposing team is not paid for work time associated with the search.
+
+In either case, the Finance Committee will take care of the formal process of setting up statements of work, signing contracts, and reviewing invoices. Other funding strategies that we have not anticipated will also be considered.
+
+Note: The Finance Committee realizes that this process may lead to a number of parallel, possibly competing searches by different groups of people. We expect all searches to follow the code of conduct with respect to fairness, non-discimination etc. Complaints to ombdus@astropy, If these procedures are violated, funding for that specific project will not be granted. Proposals planning to do a search should include the cost of job listings in their budget.
+
+In the future, we would like to offer an opportunity to propose projects that the community likes with no names attached, but right now, the Finance Committee can not commit the necessary capacity to handle such a multi-step process. 


### PR DESCRIPTION
The Astropy project has funding, currently through the Moore grant and we need to decide exactly what will be paid for with this money.

The PR introduces a *template* for internal calls for proposals that allow the community to decide how the money should be spent. On the one hand, it is important that all stakeholders in Astropy can have input, on the other hand, we need a process that generates as little extra work as possible. We want to spend our energy in improving the Astropy project (code, packages, community) and getting more resources (contributor, maintainers, funding, etc.) from the outside, not in competing with each on the money that we already have.

This PR makes a suggestion how the finance committee could issue an annual call asking to community to put forth the projects to be funded and how the community could decide on the distribution.

This proposal assumes that [APE0](https://github.com/astropy/astropy-APEs/pull/61) will be accepted to define voting members of the Astropy Project.

In this PR, we want to settle on the *general process* for distributing the money, the exact details of each internal call will have to be adjusted by the finance committee depending on what funding astropy has available in any given year (how much money? What are the detailed conditions in the grants?)