### PR TITLE
Funding 2021: Hire specutils/specreduce developer

### DIFF
--- a/finance/proposal-calls/2021-proposal/hire_spectroscopy_developer.md
+++ b/finance/proposal-calls/2021-proposal/hire_spectroscopy_developer.md
@@ -1,0 +1,24 @@
+### Hire specreduce / specutils developer
+
+### Project team
+Moritz Guenther (@hamogu) for this strawmen proposal
+
+### Project Summary
+*The Moore budget earmarks 22500 $ specifically for spectroscopy development. I submit this proposal to ensure that there is at least one spectroscopy proposal,and promise to oversee the work to the best of my abilities, but I'm happy to recind it if more detailed proposals are submitted.*
+
+Spectroscopy is a weak spot for astropy, both specutils, and even more specreduce, need love. This proposal is to hire a developer with experience in spectroscopy from the astropy community to drive development forward.
+
+### Project / work
+Spectrsocopy has been discussed in previous coordinatation meetings and both packages have maintainers that have listed items for future development in the issue trackers of these projects. I propose to hire a developer with experience in spectroscopy and select the areas from those plans and issues that that developer is most familiar with and can make the most progress on (e.g. if it's someone who has worked on long-slit spectra before, that might be an area to focus onwith IRAF in the past, then re-implementing the most requested [see issue list] IRAF functionality can be a focus).
+
+The proposed work is:
+
+- 5 h: Familiarize with both packages, identify development areas
+- 120 h: Implement new features according to list above
+- 20 h: Fix smaller open issues / bugs "along the way"
+
+
+### Budget
+- AAS job register listing: ~500 $:
+- Contractor to perform work: 145 h a 150 $/h: ~22 000 $
+- TOTAL: 22500 US $

--- a/finance/proposal-calls/2021-proposal/hire_spectroscopy_developer.md
+++ b/finance/proposal-calls/2021-proposal/hire_spectroscopy_developer.md
@@ -1,7 +1,7 @@
 ### Hire specreduce / specutils developer
 
 ### Project team
-Moritz Guenther (@hamogu) for this strawmen proposal
+Moritz Guenther (@hamogu), Erik Tollerud (@eteq), Tim Pickering (@tepickering) 
 
 ### Project Summary
 *The Moore budget earmarks 22500 $ specifically for spectroscopy development. I submit this proposal to ensure that there is at least one spectroscopy proposal,and promise to oversee the work to the best of my abilities, but I'm happy to recind it if more detailed proposals are submitted.*


### PR DESCRIPTION
*The Moore budget earmarks 22500 $ specifically for spectroscopy development. I submit this proposal to ensure that there is at least one spectroscopy proposal,and promise to oversee the work to the best of my abilities, but I'm happy to recind it if more detailed proposals are submitted.*

Spectroscopy is a weak spot for astropy, both specutils, and even more specreduce, need love. This proposal is to hire a developer with experience in spectroscopy from the astropy community to drive development forward.