### PR TITLE
Funding 2021: Work proposal Derek Homeier

### DIFF
--- a/finance/proposal-calls/2021-proposal/Derek_Homeier.md
+++ b/finance/proposal-calls/2021-proposal/Derek_Homeier.md
@@ -1,0 +1,50 @@
+### Title
+
+### Project team
+
+Derek Homeier
+
+### Project Summary
+
+Continue role as astropy core maintainer, specutils contributor and responder
+to support and contributor's issues
+
+### Project / work
+
+#### Continue role as astropy core team member.
+
+- Participate in telecons as appropriate.
+
+- SOC member of and participant in 2021 coordination meeting;
+  will continue as co-organizer for the second meeting block (May 2021).
+
+- Participate in Roadmap and HPC working group.
+
+#### Continue role as astropy.io.ascii maintainer.
+
+#### Support for Software Operations in responding to support requests:
+
+- Monitor Facebook Python in Astronomy group, Slack channels, mailing list and Github issues
+  for questions in need of response, identifying potential assignees.
+
+- Review PRs especially from new/first time contributors.
+
+#### Contribute development in other subpackages, including, but not limited to:
+
+- astropy.modeling: API documentation; clarifying use of models when operating
+  on sampled vs. binned data, as kernels for convolution etc.
+
+- astropy.cosmology (no current maintainer)
+
+#### Contribute to specutils development
+
+- Identify specutils-specific work packages in the Spectroscopy Roadmap and work
+  on them, including connection to more advanced analysis and modeling capabilities.
+
+### Budget
+currency: US $
+
+- Salary: allocating 2 hours weekly each for support and development tasks,
+          assuming holiday times will be offset at other times: 4 * 52 hours @ $120 / hour
+
+- TOTAL: $24,960

--- a/finance/proposal-calls/2021-proposal/Derek_Homeier.md
+++ b/finance/proposal-calls/2021-proposal/Derek_Homeier.md
@@ -1,5 +1,3 @@
-### Title
-
 ### Project team
 
 Derek Homeier
@@ -22,6 +20,9 @@ to support and contributor's issues
 
 #### Continue role as astropy.io.ascii maintainer.
 
+- Ensure continued functionality and potential extension of C interface wrt.
+  new architectures.
+
 #### Support for Software Operations in responding to support requests:
 
 - Monitor Facebook Python in Astronomy group, Slack channels, mailing list and Github issues
@@ -34,12 +35,19 @@ to support and contributor's issues
 - astropy.modeling: API documentation; clarifying use of models when operating
   on sampled vs. binned data, as kernels for convolution etc.
 
+- astropy.io.fits; spectral data formats and WCS-related issues
+
 - astropy.cosmology (no current maintainer)
 
 #### Contribute to specutils development
 
 - Identify specutils-specific work packages in the Spectroscopy Roadmap and work
-  on them, including connection to more advanced analysis and modeling capabilities.
+  on them.
+
+- Connection to more advanced analysis and modeling capabilities, e.g.
+  [lineutils](https://linetools.readthedocs.io/en/latest/).
+
+- Further improved support of file formats, in particular beyond FITS.
 
 ### Budget
 currency: US $


### PR DESCRIPTION
Continuing working packages from 2020 and envisioned participation in Spectroscopy work.

Work as a `specutils` developer is included here complementary to the position proposed in #175 as it is specifically focussed on the processing and analysis side as opposed to the `specreduce` part, but exact definition of roles is open to discussion.