### PR TITLE
Add an issue template to request GitHub org actions

### DIFF
--- a/.github/ISSUE_TEMPLATE/GITHUB_ADMIN.md
+++ b/.github/ISSUE_TEMPLATE/GITHUB_ADMIN.md
@@ -1,0 +1,9 @@
+---
+name: Astropy Github Organisation Administration
+about: Request that an Astropy GitHub org admin performs some action.
+labels: [github-admin]
+assignees:
+  - astropy/coordinators
+---
+
+### Description

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
Something that has been discussed this week by the infrastructure team is the need for different contributors across the project to request changes to be made to the GitHub organisation that can only be done by an org admin. The number of org admins is low, so having a way to request these in a traceable way would prevent things getting stuck and contributions slowed down.

A concrete example is adding new contributors to read only teams to be able to auto approve their GitHub Actions CI runs.

This PR adds an issue template which automatically tags an issue to perform one of these actions with a label, and assigns the issue to the CoCo team (as I think they are the only ones with org admin currently).

If this PR is to be merged someone will have to create the appropriate label on the repo.