### PR TITLE
Formalize period for improvements of affiliated packages

### DIFF
--- a/affiliated/affiliated_package_review_process.md
+++ b/affiliated/affiliated_package_review_process.md
@@ -147,11 +147,14 @@ use the singular term *editor*, although multiple people may share this role
    based on the results of the review. The editor then posts the review
    including the final decision (accept or reject) on the original pull request.
 
-   * If the package is rejected:
-       * The original author has a month to respond to any of the points in the review,
-         and the editor may decide to change the decision.
-       * If decision to reject stands after a month, the decision is posted to the pull request
-         and it is closed.
+   * If the package is not ready to be accepted:
+       * The original author has six months to respond to any of the points in the review,
+         e.g. implement suggested changes to code or documentation,
+         and the editor may decide that the package is ready to be accepted as affiliate
+	 package at this point. The editor may extend the time to implement changes up to one
+	 year at their discretion.
+       * If decision to not accept stands after that time, the decision is posted to the 
+         pull request and it is closed.
    * If the package is accepted:
        * The editor sends a reply to the astropy-dev email to publish the decision:
 
@@ -331,7 +334,7 @@ the areas above that weren't “green” yet.
 **Summary/Decision**: Thanks for your work on this package! At the moment, we
 found some issues in some of the review areas. As per the review guidelines, we
 therefore won't be able to accept this package as an affiliated package yet.
-We will leave this pull request open for a month in case you would like to
+We will leave this pull request open for six months in case you would like to
 respond to the comments and/or address any of them.
 
 *In all cases:*

--- a/affiliated/affiliated_package_review_process.md
+++ b/affiliated/affiliated_package_review_process.md
@@ -149,10 +149,10 @@ use the singular term *editor*, although multiple people may share this role
 
    * If the package is not ready to be accepted:
        * The original author has six months to respond to any of the points in the review,
-         e.g. implement suggested changes to code or documentation,
-         and the editor may decide that the package is ready to be accepted as affiliate
-	 package at this point. The editor may extend the time to implement changes up to one
-	 year at their discretion.
+         e.g., implement suggested changes to code or documentation,
+         and the editor may decide that the package is ready to be accepted as affiliated
+	  package at this point. The editor may extend the time to implement changes up to one
+	  year at their discretion.
        * If decision to not accept stands after that time, the decision is posted to the 
          pull request and it is closed.
    * If the package is accepted:


### PR DESCRIPTION
As written, the rules for affilaited pacakges give only one month of time
to resposnd to the review of an affilaited package; after that time, the
editor has no choice but to close the PR as rejected.
One month is sure sufficient to reply to a review, but not enough to implement
any changes. We know that even in astropy itself, if often takes well over a
months to open a PR, review, and merge it.
This leaves editors with two bad options: (1) Reject a package that is almost,
but not quite ready to be accepted. While a the package author can in theory
apply again at a later point, it would be a lot more friendly to wait a little
longer to give time to implement changesm or (2) accept a packages that is
almost but not quite ready for the sake of including and promoting all
community work and "to put it out there".

Additional thoughts:

- Often, improvments requested are for better integration
  with astropy (quantities, Spectrum1D) - changes that are possible but deep
  enough that no package wants to rush them through or documentation.
- In principle, we can re-review packages, but in practice we have not done
  that ever due to limited resources, so the initial review is really the best
  point in time to motivate an affilated package to improve certain areas.