### PR TITLE
Add draft of CoCo operating policies

### DIFF
--- a/policies/coco-operating-policies.md
+++ b/policies/coco-operating-policies.md
@@ -1,0 +1,120 @@
+# Astropy Coordination Committee Operating Policies
+
+This living document outlines the guiding procedures of the Astropy Coordination
+Committee.  Note that this is not meant to be exhaustive nor duplicative - for
+example, the running notes doc documents how it is meant to be used itself.
+This document instead is meant to describe procedure, and where necessary,
+policy, for how the CoCo operates.
+
+Note also: [APE0](https://github.com/astropy/astropy-APEs/blob/main/APE0.rst)
+lays out the role, election, and philosophy for the CoCo, and that content is not
+duplicated here.
+
+## Meeting Details
+
+All meetings are held remotely (using Astropy’s Zoom) except when CoCo members happen to be co-located.
+
+*Frequency*
+
+Meeting frequency can vary depending on required workload with the assent of
+the current CoCo.  The minimum expected rate is monthly
+
+*Quorum*
+
+There is currently no formal quorum for meeting or decisions. CoCo1 assumed 2,
+and CoCo2 generally informally required 3 although 2 was sometimes sufficient
+for urgent or unlikely-to-be-controversial decisions. Coco3 uses a quorum of
+3, however, members not present can leave a note in the agenda to ask to hold
+an item until they are present. At least positive 3 votes are needed for any
+decision.
+
+*Moderation*
+
+There is no dedicated chair.  Rather, the role of chair is taken on a
+per-meeting basis by a moderator who both prepares the agenda and moderates
+the discussion. The moderator role rotates through all CoCo members on a
+specified cycle (with swaps as needed to accommodate
+vacations/conflicts/etc).
+
+*Agenda/Notes*
+
+All CoCo members are able to add items to the agenda at any time, subject to
+approval of the meeting moderator. Notes are taken in the same document as
+the agenda. The CoCo is collectively responsible for the accuracy of the
+notes.
+
+## Voting
+
+The CoCo aims for consensus when making decisions.  However if this is
+impractical in a timely manner (i.e. the committee is deadlocked), or the
+item under discussion is judged to be important enough by assent of the
+committee, a vote may be requested. The following are additional useful
+guidelines for votes:
+
++ If a choice is change vs stay the same, status quo should be default - hence ties
+  should generally lead to status quo.
++ If the CoCo is deadlocked, the issue may be better put to the broader community or
+  the Astropy Voting Membership. This is particularly true for especially “weighty”
+  decisions, and the CoCo should feel free to put the question to the broader
+  community in place of decision by close votes.
+
+## Outward Communication Channels
+
++ The running notes should be open.
+
++ To make announcements to the Astropy community, the CoCo generally relies upon
+  relevant mailing lists and forums.  When sending such announcements from the CoCo,
+  a CoCo member should be careful to sign a message as:
+
+        For the Astropy Coordination Committee,
+        <Name>
+
++ When sending a message as an individual member of the project (or in one of their
+  other roles), they should sign in whatever other way they prefer.
+
+## Internal Communication channels
+
+*Coordinators Mailing List/Google group (coordinators@astropy.org)*
+
+Used for private conversations between the coordinators and specific individuals or
+just among the coordinators. There is an expectation that messages in this group might
+be private communication.  Hence, without the CoCo’s agreement, these emails are not
+to be shared outside of the CoCo, although future CoCos will be able to see them.
+
+*Private Slack channel (`#coordinatorsNN`)*
+
+Used for private, informal conversations among CoCo members. A new channel is created
+each time CoCo membership changes. There is a strong expectation of privacy and
+messages should not be shared without express permission of the sender.
+
+*Other Project Emails (e.g. confidential@astropy.org)*
+
+As with the coordinators list, there is generally an expectation of privacy from those
+who send to these emails, although that varies with the email.
+`confidential@astropy.org` has particular status in that it goes direct to the
+Project Ombudsperson.
+
+## CoCo membership history
+
+### CoCo3 (Elected Sep 2021)
+
+- Kelle Cruz - Three year term
+- Matt Craig - One year term
+- Moritz Gunther - Two year term
+- Adrian Price-Whelan - One year term
+- Erik Tollerud - Two year term
+
+### CoCo2 (appointed upon Perry’s voluntary departure)
+#### 2013? – 2021
+
+- Tom Aldcroft
+- Kelle Cruz
+- Tom Robitaille
+- Erik Tollerud
+
+### CoCo1 (elected as a single slate)
+#### 2008? - 2013?
+- Perry Greenfield
+- Tom Robitaille
+- Erik Tollerud
+


### PR DESCRIPTION
The intent of this is to let the community know how the CoCo intends to operate, to clarify some of the communication channels to/from the CoCo and to provide an outline for future CoCos as to how we operated.