### PR TITLE
Phase 3 Funding: Improving Compressed Image performance and Dask integration in `io.fits`.

### DIFF
--- a/finance/proposal-calls/cycle3/aperio_fits_dask.md
+++ b/finance/proposal-calls/cycle3/aperio_fits_dask.md
@@ -69,10 +69,34 @@ Some relevant issues:
 
 While this is one of the largest performance issues in `io.fits`, this project
 is also proposing to increase the integration of Dask with `io.fits` which will
-enable significant performance improvements when using FITS files with
-distributed compute.
+enable significant performance improvements when using FITS files with dask.
+
+This proposal is focusing on images in FITS files, so both uncompressed images
+and compressed images (which are stored in binary tables underneath), and
+proposes to add an option to `io.fits` to read both these types of FITS arrays
+directly into Dask arrays.
+
+While the proposal team has significant experience with reading various data
+formats into Dask arrays, for example FITS images and CASA images and tables.
+A proportion of the development time for this section of the proposal will be
+devoted to researching the most effective method of loading FITS files into Dask
+arrays.
+
+Currently it is
+[possible](https://github.com/sunpy/sunpy/issues/2715#issuecomment-413286821) to
+load an image into a Dask array, via the "delayed" functionality in Dask. In
+this case, the file is opened when reading a chunk of data from the array, and
+then closed again afterwards.
+This approach works well for a lot of use cases, but is complex, it would be a
+lot better if this were integrated into `io.fits` directly.
+
+For compressed images, Dask integration would allow you to process the
+compressed chunks of the image in parallel (either on a single machine or
+distributed), as if each compressed tile of the image was a dask chunk then it
+can be parallelised over using the various dask schedulers.
+
+This proposal is to get an initial implementation of both of these read use
+cases integrated into `io.fits`, and in the process to document any future
+improvements that could be made to enhance performance.
 
 ### Approximate Budget
-
-Money in return for the sacrifice of sanity required to rework large chunks of
-`io.fits`. /s

--- a/finance/proposal-calls/cycle3/aperio_fits_dask.md
+++ b/finance/proposal-calls/cycle3/aperio_fits_dask.md
@@ -1,0 +1,40 @@
+### Title
+Improve FITS compressed image support and Dask integration in `io.fits`.
+
+### Project Team
+Stuart Mumford
+Thomas Robitaille
+Drew Leonard
+
+### Project Description
+
+This project aims to increase performance of `io.fits` especially around large
+compressed image data.
+
+Currently when using tiled FITS compression the Astropy implementation loads
+all the tiles into RAM and decompresses them all.
+This is highly CPU and memory inefficient, and is one of the reasons Astropy is
+significantly slower at loading these types of files than the `cfitsio` package
+(which uses the same C library as Astropy for this currently).
+
+While this is one of the largest performance issues in `io.fits`, this project
+is also proposing to increase the integration of Dask with `io.fits` which will
+enable significant performance improvements when using FITS files with
+distributed compute.
+
+It's likely that any significant refactor of `CompImageHDU` will lead to an
+implementation not using the `fitsio` C library see
+[#3895](https://github.com/astropy/astropy/issues/3895) which also has the side
+effect of significantly reducing the compile time complexity of Astropy, as
+this is the only part of the code which uses `fitsio`.
+
+Some relevant issues:
+
+* https://github.com/astropy/astropy/issues/3895
+* https://github.com/astropy/astropy/issues/11633
+* https://github.com/astropy/astropy/issues/9238
+
+### Approximate Budget
+
+Money in return for the sacrifice of sanity required to rework large chunks of
+`io.fits`. /s

--- a/finance/proposal-calls/cycle3/aperio_fits_dask.md
+++ b/finance/proposal-calls/cycle3/aperio_fits_dask.md
@@ -97,9 +97,9 @@ package.
 
 Some relevant issues:
 
-* https://github.com/astropy/astropy/issues/3895
-* https://github.com/astropy/astropy/issues/11633
-* https://github.com/astropy/astropy/issues/9238
+* Compressed HDU enhancements [#3895](https://github.com/astropy/astropy/issues/3895)
+* Writing compressed FITS files is slow when multi-threaded [#11633](https://github.com/astropy/astropy/issues/11633)
+* Refactor FITS compressed image headers (CompImageHeader) [#9238](https://github.com/astropy/astropy/issues/9238)
 
 
 #### Dask Integration with reading FITS files

--- a/finance/proposal-calls/cycle3/aperio_fits_dask.md
+++ b/finance/proposal-calls/cycle3/aperio_fits_dask.md
@@ -131,7 +131,13 @@ lot better if this were integrated into `io.fits` directly. For example, somethi
 
 ```python
 hdulist = fits.open(filepath, use_dask=True)
-hdulist[0].data
+hdulist
+```
+```
+[<astropy.io.fits.hdu.image.DaskPrimaryHDU object at 0x7f1824914c10>, <astropy.io.fits.hdu.table.DaskCompImageHDU object at 0x7f1824914ee0>]
+```
+```python
+hdulist[1].data
 ```
 ```
 dask.array<reshape, shape=(4, 490, 1000, 2560), dtype=float64, chunksize=(1, 1, 1000, 2560), chunktype=numpy.ndarray>
@@ -148,3 +154,22 @@ cases integrated into `io.fits`, and in the process to document any future
 improvements that could be made to enhance performance.
 
 ### Approximate Budget
+
+For part one, we would request a total of 150h @ $150/hour broken up into:
+
+* 100h for removing the cfitsio dependency on `CompImageHDU`. This includes
+  reimplementing or adapting the C implementation of the tile (de)compression
+  algorithms, and modifying `CompImageHDU` to use the new astropy versions of
+  these algorithms rather than parsing all the data to `cfitsio` for loading.
+* 50h for implementing a new lazy-loading property on `CompImageHDU` which
+  allows users to load parts of the whole compressed image array without having
+  to load and decompress the whole array.
+
+For part two, we request another 100h @ $150/hour to implement prototype loaders
+for FITS Image HDUs making use of Dask. At the end of part two we expect to have
+at least one approach to efficiently loading FITS data into Dask, suitable for
+large scale parallelisation, and a plan of how these prototypes could be
+improved upon and merged into astropy core.
+
+Our minimal budget is the 150h requested for part one, which would mean leaving
+all the Dask work to another proposal.

--- a/finance/proposal-calls/cycle3/aperio_fits_dask.md
+++ b/finance/proposal-calls/cycle3/aperio_fits_dask.md
@@ -1,5 +1,5 @@
 ### Title
-Improve FITS compressed image support and Dask integration in `io.fits`.
+Improve FITS compressed image performance and Dask integration in `io.fits`.
 
 ### Project Team
 Stuart Mumford
@@ -19,44 +19,81 @@ This is highly CPU and memory inefficient, and is one of the reasons Astropy is
 significantly slower at loading these types of files than the `cfitsio` package
 (which uses the same C library as Astropy for this currently).
 
-For example we can compare the loading times of `io.fits` vs `cfitsio`:
+For example we can compare the loading times of `io.fits` vs [`fitsio`](https://github.com/esheldon/fitsio):
 
-Loading a whole array with astropy:
+<details>
+<summary>Setup Code</summary>
 
-```
-In [44]: %timeit fits.getdata("VBI_L1_00656282_2018_05_11T14_25_05_466665_I.fits", hdu=1)
-183 ms ± 248 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
-```
+```python
+import os
+from pathlib import Path
 
-with cfitsio:
-```
-In [45]: %timeit hdu[1][:, :]
-131 ms ± 182 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
-```
+import fitsio
+from astropy.io import fits
+import astropy.units as u
 
-loading one or more individual tiles with `cfitsio`:
-```
-In [48]: %timeit hdu[1][0, 0]
-21.6 µs ± 191 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+filename = "VISP_2022_06_17T19_17_52_516_00630205_U_BLQRA_L1.fits"
+path = Path("~/dkist_data/BLQRA").expanduser() / filename
 
-In [49]: %timeit hdu[1][0, :]
-22.3 µs ± 78.2 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
-
-In [50]: %timeit hdu[1][:10, :]
-235 µs ± 718 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
+fio = fitsio.FITS(path)
 ```
 
-note that doing the same operations with astropy currently loads the whole file
-so takes the same amount of time as the first `getdata` call. This means that
-loading a single tile with astropy is approximately 8300x slower than with
-`cfitsio`!!
+</details>
+
+```python
+# Filesize
+print((os.stat(path).st_size * u.byte).to(u.Mibyte))
+```
+```
+2.04071044921875 Mibyte
+```
+
+```python
+raw_hdul = fits.open(path, disable_image_compression=True)
+header = raw_hdul[1].header
+
+print(f"{header['ZNAXIS1']=}")
+print(f"{header['ZNAXIS2']=}")
+print(f"{header['ZNAXIS3']=}")
+print(f"{header['ZTILE1']=}")
+print(f"{header['ZTILE2']=}")
+print(f"{header['ZTILE3']=}")
+```
+```
+header['ZNAXIS1']=2560
+header['ZNAXIS2']=1000
+header['ZNAXIS3']=1
+header['ZTILE1']=256
+header['ZTILE2']=256
+header['ZTILE3']=1
+```
+
+```
+# Time loading all the array with astropy
+%timeit fits.getdata(path, hdu=1)
+75.4 ms ± 597 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+
+# Time loading all the array with fitsio
+%timeit fio[1][:,:,:]
+25.6 ms ± 311 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+
+# Time loading a single chunk
+%timeit fio[1][0,0,0]
+24.6 µs ± 757 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+```
+
+note that opening the file with astropy currently loads the whole array
+so takes the same amount of time as the first `getdata` call.
 
 Issue [#3895](https://github.com/astropy/astropy/issues/3895) has been open
 since 2015 and describes a set of deep improvements for the compressed image
 support in `io.fits`. This includes implementing the compression natively in
-Python rather than using the `fitsio` C library to do it. This will have the
+Python rather than using the `cfitsio` C library to do it. This will have the
 side effect of significantly reducing the compile time complexity of Astropy, as
-this is the only part of the code which uses `fitsio`.
+the bundled cfitsio library could then be removed from the core package (as it
+was only used for the compression). We expect that we would address all of the
+points in this issue during development of a native Python tile [de]compression
+package.
 
 Some relevant issues:
 
@@ -67,30 +104,41 @@ Some relevant issues:
 
 #### Dask Integration with reading FITS files
 
-While this is one of the largest performance issues in `io.fits`, this project
-is also proposing to increase the integration of Dask with `io.fits` which will
-enable significant performance improvements when using FITS files with dask.
+While handling compression without loading the whole array is one of the largest
+performance issues in `io.fits`, this project is also proposing to increase the
+integration of Dask with `io.fits` which will enable significant performance
+improvements when using FITS files with dask.
 
-This proposal is focusing on images in FITS files, so both uncompressed images
-and compressed images (which are stored in binary tables underneath), and
+This proposal is focusing on image HDUs in FITS files, so both uncompressed
+images and compressed images (which are stored in binary tables underneath), and
 proposes to add an option to `io.fits` to read both these types of FITS arrays
 directly into Dask arrays.
 
-While the proposal team has significant experience with reading various data
+The proposal team has significant experience with reading various data
 formats into Dask arrays, for example FITS images and CASA images and tables.
 A proportion of the development time for this section of the proposal will be
 devoted to researching the most effective method of loading FITS files into Dask
 arrays.
 
 Currently it is
-[possible](https://github.com/sunpy/sunpy/issues/2715#issuecomment-413286821) to
-load an image into a Dask array, via the "delayed" functionality in Dask. In
-this case, the file is opened when reading a chunk of data from the array, and
-then closed again afterwards.
+[possible](https://github.com/sunpy/sunpy/issues/2715#issuecomment-413286821)
+but not trivial to load an image from a FITS file into a Dask array, via the
+"delayed"
+functionality in Dask. In this case, the file is opened when reading a chunk of
+data from the array, and then closed again afterwards.
 This approach works well for a lot of use cases, but is complex, it would be a
-lot better if this were integrated into `io.fits` directly.
+lot better if this were integrated into `io.fits` directly. For example, something akin to:
 
-For compressed images, Dask integration would allow you to process the
+```python
+hdulist = fits.open(filepath, use_dask=True)
+hdulist[0].data
+```
+```
+dask.array<reshape, shape=(4, 490, 1000, 2560), dtype=float64, chunksize=(1, 1, 1000, 2560), chunktype=numpy.ndarray>
+```
+
+
+For compressed images, Dask integration would allow users to process the
 compressed chunks of the image in parallel (either on a single machine or
 distributed), as if each compressed tile of the image was a dask chunk then it
 can be parallelised over using the various dask schedulers.

--- a/finance/proposal-calls/cycle3/aperio_fits_dask.md
+++ b/finance/proposal-calls/cycle3/aperio_fits_dask.md
@@ -92,8 +92,8 @@ Python rather than using the `cfitsio` C library to do it. This will have the
 side effect of significantly reducing the compile time complexity of Astropy, as
 the bundled cfitsio library could then be removed from the core package (as it
 was only used for the compression). We expect that we would address all of the
-points in this issue during development of a native Python tile [de]compression
-package.
+points in this issue during development of a tile [de]compression package
+independent of cfitsio.
 
 Some relevant issues:
 

--- a/finance/proposal-calls/cycle3/aperio_fits_dask.md
+++ b/finance/proposal-calls/cycle3/aperio_fits_dask.md
@@ -173,3 +173,6 @@ improved upon and merged into astropy core.
 
 Our minimal budget is the 150h requested for part one, which would mean leaving
 all the Dask work to another proposal.
+
+### Approved Budget
+$22,500.00

--- a/finance/proposal-calls/cycle3/aperio_fits_dask.md
+++ b/finance/proposal-calls/cycle3/aperio_fits_dask.md
@@ -11,21 +11,51 @@ Drew Leonard
 This project aims to increase performance of `io.fits` especially around large
 compressed image data.
 
+#### Compressed Image Performance
+
 Currently when using tiled FITS compression the Astropy implementation loads
 all the tiles into RAM and decompresses them all.
 This is highly CPU and memory inefficient, and is one of the reasons Astropy is
 significantly slower at loading these types of files than the `cfitsio` package
 (which uses the same C library as Astropy for this currently).
 
-While this is one of the largest performance issues in `io.fits`, this project
-is also proposing to increase the integration of Dask with `io.fits` which will
-enable significant performance improvements when using FITS files with
-distributed compute.
+For example we can compare the loading times of `io.fits` vs `cfitsio`:
 
-It's likely that any significant refactor of `CompImageHDU` will lead to an
-implementation not using the `fitsio` C library see
-[#3895](https://github.com/astropy/astropy/issues/3895) which also has the side
-effect of significantly reducing the compile time complexity of Astropy, as
+Loading a whole array with astropy:
+
+```
+In [44]: %timeit fits.getdata("VBI_L1_00656282_2018_05_11T14_25_05_466665_I.fits", hdu=1)
+183 ms ± 248 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
+```
+
+with cfitsio:
+```
+In [45]: %timeit hdu[1][:, :]
+131 ms ± 182 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+```
+
+loading one or more individual tiles with `cfitsio`:
+```
+In [48]: %timeit hdu[1][0, 0]
+21.6 µs ± 191 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+
+In [49]: %timeit hdu[1][0, :]
+22.3 µs ± 78.2 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+
+In [50]: %timeit hdu[1][:10, :]
+235 µs ± 718 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
+```
+
+note that doing the same operations with astropy currently loads the whole file
+so takes the same amount of time as the first `getdata` call. This means that
+loading a single tile with astropy is approximately 8300x slower than with
+`cfitsio`!!
+
+Issue [#3895](https://github.com/astropy/astropy/issues/3895) has been open
+since 2015 and describes a set of deep improvements for the compressed image
+support in `io.fits`. This includes implementing the compression natively in
+Python rather than using the `fitsio` C library to do it. This will have the
+side effect of significantly reducing the compile time complexity of Astropy, as
 this is the only part of the code which uses `fitsio`.
 
 Some relevant issues:
@@ -33,6 +63,14 @@ Some relevant issues:
 * https://github.com/astropy/astropy/issues/3895
 * https://github.com/astropy/astropy/issues/11633
 * https://github.com/astropy/astropy/issues/9238
+
+
+#### Dask Integration with reading FITS files
+
+While this is one of the largest performance issues in `io.fits`, this project
+is also proposing to increase the integration of Dask with `io.fits` which will
+enable significant performance improvements when using FITS files with
+distributed compute.
 
 ### Approximate Budget
 


### PR DESCRIPTION
In this PR we propose development effort to improve the state of compressed image support in `astropy.io.fits` and to implement initial support for reading FITS files into Dask arrays.

This proposal is in two parts:
* **Part one**: Implement a tiled decompression/compression package to replace astropy's current use of `cfitsio`, to simplify the codebase and to open the door to substantial performance improvements.
* **Part two**: Write an initial implementation of loading FITS ImageHDUs directly in to `Dask` arrays (both compressed and uncompressed images. [Note that writing from a Dask array is already implemented.]

[Rendered Proposal](https://github.com/Cadair/astropy-project/blob/aperio_fits/finance/proposal-calls/cycle3/aperio_fits_dask.md)