### PR TITLE
Phase 3 funding: Addressing long-standing bugs and feature requests by monetary bounty

### DIFF
--- a/finance/proposal-calls/cycle3/bounties.md
+++ b/finance/proposal-calls/cycle3/bounties.md
@@ -3,7 +3,7 @@
 ### Project Team
 This project will put bounties on specific issues, that can be collecrted by anyone (which includes people without previous involvement in astropy) who writes a PR that closes that issue.
 
-The progam is organized by: Moritz Guenther (@hamogu), your..name..here..
+The progam is organized by: Moritz Guenther (@hamogu), Erik Tollerud (@eteq) your..name..here..
 
 ### Project Description
 Address long-standing bugs or missing features that volunteers don't address.

--- a/finance/proposal-calls/cycle3/bounties.md
+++ b/finance/proposal-calls/cycle3/bounties.md
@@ -18,11 +18,22 @@ We'll in particular see if the community is interested in earning the bug bounti
 
 To this end we will select the following issues, which are over 3 years old, look reasonably self-contained, and could be addressed (i.e. don't need work on several other issues before they can be addressed) by a variety of developers (i.e. they may be complex in programming, but don't require APEs or decision on API that only the maintainers can make):
 
-- issue xxx: 500 $ for PR and 125 $ for review
-- issue yyy: 1000 $ for PR and 250 $ for review
--
+- https://github.com/astropy/astropy/issues/4112 - 300 $ + 75 $ for review
+- https://github.com/astropy/astropy/issues/3720 - 300 $+ 75 $ for review
+- https://github.com/astropy/astropy/issues/4121 - 1600 $ + 400 $ for review
+- https://github.com/astropy/astropy/issues/4610 - 1600 $ + 400 $ for review
+- https://github.com/astropy/astropy/issues/1803 - 3000 $ + 750 $ for review
+- https://github.com/astropy/astropy/issues/1783 - 1600 $  + 400 $ for review
+- https://github.com/astropy/astropy/issues/3214 - 300 $ + 75 $ for review
+- https://github.com/astropy/astropy/issues/3081 - 1600 $ + 400 $ for review
+- https://github.com/astropy/astropy/issues/6848 - 1600 $ + 400 $ for review
+- https://github.com/astropy/astropy/issues/6618 - 1600 $ + 400 $ for review
+- https://github.com/astropy/astropy/issues/6617 - 600 $ + 150 $ for review
+- https://github.com/astropy/astropy/issues/6583 - 3000 $ + 750 $ for review
+- https://github.com/astropy/astropy/issues/6549 - 1600 $ + 400 $ for review
+- https://github.com/astropy/astropy/issues/6548 - 1600 $ + 400 $ for review
 
-(please suggest issues for this list during the discussion phase)
+(please suggest further issues for this list during the discussion phase)
 
 Bounties should be set high-enough to attract developers to complex, long-standing issues and give a reasonable rate of return. However, it is impossible to know in advance exactly how much work a specific PR will bring, and the point of this funding request is to try out bounties on a number of issues and see if our (i.e. the people contributing to the list above) intuition works.
 
@@ -35,8 +46,8 @@ We do not want this proposal to increase the workload for volunteer reviewers, s
 
 ### Approximate Budget
 
-about 20000 $
+10000 $ to 20000 $
 
-(exact sum to be calculated beased on the list of issues with a bounty that will be collected in the discussion phase.)
+It is to be expected that developers will selectively pick and choose and not all issues will be worked on. We will keep a running tally of the funding; this program simply ends when it runs out of money.
 
 This is a pilot program to work out how it works - we want to more than a handful of issues to make sure we have enough uptake to work out the proccess, but not so much money that we have a big problem if it's not working out.

--- a/finance/proposal-calls/cycle3/bounties.md
+++ b/finance/proposal-calls/cycle3/bounties.md
@@ -1,0 +1,42 @@
+### Addressing long-standing bugs and feature requests by putting a monetary bounty
+
+### Project Team
+This project will put bounties on specific issues, that can be collecrted by anyone (which includes people without previous involvement in astropy) who writes a PR that closes that issue.
+
+The progam is organized by: Moritz Guenther (@hamogu), your..name..here..
+
+### Project Description
+Address long-standing bugs or missing features that volunteers don't address.
+
+### Project / Work
+The idea to use funding is to address long-standing issues and bugs, that apparently no volunteer has time or interest to take on. So, we could put a bounty in dollars on those issues, which gets paid to whoever gets a PR merged that successfully closes that issue.
+
+This concept is simple in principle, but raises a number of questions about the implementation. Who decides which issues are old enough to say "without money, this will never be done"? How much money do we put on each issue and which issues are important enough to pay for? Does the money actually motivate people to address things, or are those issues and bugs still open for other reasons (e.g. there is no known solution that's technically feasible)? Is there social pressure on reviewers to accept half-finished PRs because someone "needs the money for a living"? Will there even competition and wasted effort because suddenly several developers jump on the same issues?
+
+We believe that there is no way to design a perfect process in advance, we'll just have to take the plunge and try it out. Thus, we propose to put a limited amount of money (see budget below) into "issue bounties".
+We'll in particular see if the community is interested in earning the bug bounties and what amount of money is required to make this work.
+
+To this end we will select the following issues, which are over 3 years old, look reasonably self-contained, and could be addressed (i.e. don't need work on several other issues before they can be addressed) by a variety of developers (i.e. they may be complex in programming, but don't require APEs or decision on API that only the maintainers can make):
+
+- issue xxx: 500 $ for PR and 125 $ for review
+- issue yyy: 1000 $ for PR and 250 $ for review
+-
+
+(please suggest issues for this list during the discussion phase)
+
+Bounties should be set high-enough to attract developers to complex, long-standing issues and give a reasonable rate of return. However, it is impossible to know in advance exactly how much work a specific PR will bring, and the point of this funding request is to try out bounties on a number of issues and see if our (i.e. the people contributing to the list above) intuition works.
+
+Bounty hunters are encouraged, but not required, to post a comment at an issue when they start working on it. Whoever authors the PR that closes the issue can submit an invoice to NumFOCUS to claim the bounty; bounties can be split if requested by the author of the PR.
+We anticipate that only a limited number of people will choose to work on this program and that the workload for NumFOCUS and the finance committee to approve and handle the payments is acceptable. However, the total amount of money in this program for this year is small enough, that it can be done even if every bounty goes a new and entirely different person, who has never received funding from NumFOCUS before.
+
+Bounty hunters assume the risk that somebody else might have a PR to close their issue first or that an issue might turn out to be more complicated that expected. The bounty sums are set when this proposal is accepted and will not be adjusted.
+
+We do not want this proposal to increase the workload for volunteer reviewers, so whoever leaves the most substantial review comments, can claim 25% of the bounty sum. We anticipate that it will tyically be clear and uncontroversial who has the right to claim the "review bounty" and that some fraction of reviewers might not claim the reward anyway. However, the point of this program is to test such assumptions in real live. For this year, and this year only, all disputes about who can claim the bounty will be decided the the group of people listed as organizers of this program. 
+
+### Approximate Budget
+
+about 20000 $
+
+(exact sum to be calculated beased on the list of issues with a bounty that will be collected in the discussion phase.)
+
+This is a pilot program to work out how it works - we want to more than a handful of issues to make sure we have enough uptake to work out the proccess, but not so much money that we have a big problem if it's not working out.

--- a/finance/proposal-calls/cycle3/bounties.md
+++ b/finance/proposal-calls/cycle3/bounties.md
@@ -51,3 +51,6 @@ We do not want this proposal to increase the workload for volunteer reviewers, s
 It is to be expected that developers will selectively pick and choose and not all issues will be worked on. We will keep a running tally of the funding; this program simply ends when it runs out of money.
 
 This is a pilot program to work out how it works - we want to more than a handful of issues to make sure we have enough uptake to work out the proccess, but not so much money that we have a big problem if it's not working out.
+
+### Approved Budget
+$20,000


### PR DESCRIPTION
The idea to use funding is to address long-standing issues and bugs, that apparently no volunteer has time or interest to take on. So, we could put a bounty in dollars on those issues, which gets paid to whoever gets a PR merged that successfully closes that issue.

This concept is simple in principle, but raises a number of questions about the implementation. Who decides which issues are old enough to say "without money, this will never be done"? How much money do we put on each issue and which issues are important enough to pay for? Does the money actually motivate people to address things, or are those issues and bugs still open for other reasons (e.g. there is no known solution that's technically feasible)? Is there social pressure on reviewers to accept half-finished PRs because someone "needs the money for a living"? Will there even competition and wasted effort because suddenly several developers jump on the same issues?

We believe that there is no way to design a perfect process in advance, we'll just have to take the plunge and try it out. Thus, we propose to put a limited amount of money (see budget below) into "issue bounties".
We'll in particular see if the community is interested in earning the bug bounties and what amount of money is required to make this work.