### PR TITLE
Phase 3 Funding:  Fill vacant community engagement coordinator/community manager role

### DIFF
--- a/finance/proposal-calls/cycle3/community-manager.md
+++ b/finance/proposal-calls/cycle3/community-manager.md
@@ -7,7 +7,26 @@ This is an open hire, to be lead by Kelle Cruz (@kelle), Erik Tollerud (@eteq), 
 ### Project Description
 The [community engagement coordinator position](https://www.astropy.org/team.html#Community_engagement_coordinator) is currently unfilled and there's not clear eveidence that anyone wants to fill it. While this may seem like a position that requires specialized knowledge of our community, the general position of open source community manager has a lot of history of specialist professionals who work at it - e.g. [Red Hat](https://www.redhat.com/en/blog/many-faces-community-manager), [FOSSlife](https://www.fosslife.org/what-open-source-community-manager), [The Linux Foundation](https://www.linuxfoundation.org/tools/building-leadership-in-an-open-source-community/). So this proposal aims to do an open hire drawing from this pool.
 
-(Exact duties to be filled out in the review stage)
+Some tasks the holder of this role might take include: 
+* Monthly updates requested by NumFOCUS for their newsletter
+* Discourse, Stack Exchange, and Facebook group moderation and crossposting
+* Slack moderation and crossposting
+* Twitter post of announcements and replies to mentions
+* Help with Coordination Meetings
+* Help expanding workshops to more varied users
+* Help publicizing Learn Astropy resources
+* Coordinating website content refresh and updates with web site maintainers
+* Community and/or User Survey
+* More regular updates on a blog or the main Astropy website
+
+Which of these a particular candidate takes on may depend on their background knowledge and skillset.
+
+Selection criteria for a hire would include:
+* Experience working with or in open source projects analogous to Astropy
+* Experience with or training on community manager work like that listed in the links above
+* Understanding of the goals of Astropy
+* Understanding of both our user and developer communities
+
 
 ### Approximate Budget
 Roughly 24960 USD, based on 10% time over a year for someone at $120/hr.

--- a/finance/proposal-calls/cycle3/community-manager.md
+++ b/finance/proposal-calls/cycle3/community-manager.md
@@ -1,0 +1,13 @@
+### Title
+Hire a community manager
+
+### Project Team
+This is an open hire, to be lead by Kelle Cruz (@kelle), Erik Tollerud (@eteq), Adrian Price-Whelan (@adrn), and any others who are interested
+
+### Project Description
+The [community engagement coordinator position](https://www.astropy.org/team.html#Community_engagement_coordinator) is currently unfilled and there's not clear eveidence that anyone wants to fill it. While this may seem like a position that requires specialized knowledge of our community, the general position of open source community manager has a lot of history of specialist professionals who work at it - e.g. [Red Hat](https://www.redhat.com/en/blog/many-faces-community-manager), [FOSSlife](https://www.fosslife.org/what-open-source-community-manager), [The Linux Foundation](https://www.linuxfoundation.org/tools/building-leadership-in-an-open-source-community/). So this proposal aims to do an open hire drawing from this pool.
+
+(Exact duties to be filled out in the review stage)
+
+### Approximate Budget
+Roughly 24960 USD, based on 10% time over a year for someone at $120/hr.

--- a/finance/proposal-calls/cycle3/community-manager.md
+++ b/finance/proposal-calls/cycle3/community-manager.md
@@ -7,7 +7,7 @@ This is an open hire, to be lead by Kelle Cruz (@kelle), Erik Tollerud (@eteq), 
 ### Project Description
 The [community engagement coordinator position](https://www.astropy.org/team.html#Community_engagement_coordinator) is currently unfilled and there's not clear eveidence that anyone wants to fill it. While this may seem like a position that requires specialized knowledge of our community, the general position of open source community manager has a lot of history of specialist professionals who work at it - e.g. [Red Hat](https://www.redhat.com/en/blog/many-faces-community-manager), [FOSSlife](https://www.fosslife.org/what-open-source-community-manager), [The Linux Foundation](https://www.linuxfoundation.org/tools/building-leadership-in-an-open-source-community/). So this proposal aims to do an open hire drawing from this pool.
 
-Some tasks the holder of this role might take include: 
+Some tasks the holder of this role would take on include: 
 * Monthly updates requested by NumFOCUS for their newsletter
 * Discourse, Stack Exchange, and Facebook group moderation and crossposting
 * Slack moderation and crossposting
@@ -18,6 +18,7 @@ Some tasks the holder of this role might take include:
 * Coordinating website content refresh and updates with web site maintainers
 * Community and/or User Survey
 * More regular updates on a blog or the main Astropy website
+* New community-oriented initiatives as they come up
 
 Which of these a particular candidate takes on may depend on their background knowledge and skillset.
 

--- a/finance/proposal-calls/cycle3/community-manager.md
+++ b/finance/proposal-calls/cycle3/community-manager.md
@@ -30,5 +30,4 @@ Selection criteria for a hire would include:
 
 
 ### Approximate Budget
-Roughly 24960 USD, based on 10% time over a year for someone at $120/hr.
-test
+The budget has flexibility. Our minimum request is for $15,000/year to find someone to take the lead on only a few of the above listed tasks. At the high end, with $60,000/year, we could find someone to spending approximately 50% time on Astropy and to make progress on most of the tasks.

--- a/finance/proposal-calls/cycle3/community-manager.md
+++ b/finance/proposal-calls/cycle3/community-manager.md
@@ -17,10 +17,14 @@ Some tasks the holder of this role would take on include:
 * Help publicizing Learn Astropy resources
 * Coordinating website content refresh and updates with web site maintainers
 * Community and/or User Survey
+* Coordinate update to the Astropy Code of Conduct
 * More regular updates on a blog or the main Astropy website
 * New community-oriented initiatives as they come up
 
 Which of these a particular candidate takes on may depend on their background knowledge and skillset.
+
+### Selection Process
+Our selection process would be informed by the [resources provided by the Center for Scientific Collaboration and Community Engagement (CSCCE)](https://www.cscce.org/resources/hiring-becoming-a-community-manager/). The CSCCE hosts an active Slack workspace with over 450 members and we plan to use that community for recruiting and adverisement, in addition to posting to the AAS Job Register. 
 
 Selection criteria for a hire would include:
 * Experience working with or in open source projects analogous to Astropy

--- a/finance/proposal-calls/cycle3/community-manager.md
+++ b/finance/proposal-calls/cycle3/community-manager.md
@@ -31,3 +31,4 @@ Selection criteria for a hire would include:
 
 ### Approximate Budget
 Roughly 24960 USD, based on 10% time over a year for someone at $120/hr.
+test

--- a/finance/proposal-calls/cycle3/community-manager.md
+++ b/finance/proposal-calls/cycle3/community-manager.md
@@ -35,3 +35,9 @@ Selection criteria for a hire would include:
 
 ### Approximate Budget
 The budget has flexibility. Our minimum request is for $15,000/year to find someone to take the lead on only a few of the above listed tasks. At the high end, with $60,000/year, we could find someone to spending approximately 50% time on Astropy and to make progress on most of the tasks.
+
+### Approved Budget
+
+This project was approved for a *total* budget of $48,000.
+
+Note that — unlike the budget suggested by the proposers — that is a sum, rather than a rate. Discussion of the period of performance will follow on the implementation issue.


### PR DESCRIPTION
An open call to hire someone into the community engagement coordinator role (see the text for a bit more justification on how this makes sense as an open call).

I included @kelle and @adrn based on earlier discussions with them, although they are welcome to bow-out if I misunderstood!