### PR TITLE
added instruction for future funding calls

### DIFF
--- a/finance/proposal-calls/templates/project_template.md
+++ b/finance/proposal-calls/templates/project_template.md
@@ -1,0 +1,24 @@
+### Title
+
+### Project Team
+Describe who is expected to work on the project. If work will be undertaken by an open hire instead of (or in addition to) other project members, please indicate that here.
+
+### Project Description
+How does this benefit Astropy packages / users / community / ...? Short summary.
+In particular for projects that are most useful for people outside the group of experienced contributors reading your project description, some context (size of audience, existing use cases etc.) might help.
+
+### Project / Work
+Details here as needed for Astropy community members to understand what is planned.
+
+### Approximate Budget
+Currency: US $
+The approximate budget should be specified in USD. However, we are open to spending funds worldwide. Budgets should be converted to USD using a plausible exchange rate.
+
+Include overheads, fringe, etc. if money is paid as sub-grant (note that the Moore grant caps overhead at 15%).
+
+- Travel:
+- Conference Registrations:
+- Salary / contractor fees etc. (give sum here, details about contract, payment method (contract/sub-award) etc. can be worked out with the finance committee later)
+- TOTAL
+
+Please note that we would happily accept budget items other than travel, conference registration, and staff.


### PR DESCRIPTION
This PR is the result of me readinf the cycle 3 project description. In some cases, I really did not know how to vote because it was unclear to me who benefits from this proposal. For example, for the AstropyLearn proposal a little more specific info (e.g. page views, use cases, audiences) would have helped me to understand if this will be money well spend.

The same is true for a few other proposals in cycle 3; so I tried to add a sentence so that people who write future funding requests can keep that in mind. 

Since it's not appropriate to change the doc in the cycle3 directory at this stage, I've copied the file to the template directory where it will be found next year.