### PR TITLE
Add draft October 2022 Finance Ctte update

### DIFF
--- a/finance/community-updates/2022-10.txt
+++ b/finance/community-updates/2022-10.txt
@@ -4,12 +4,12 @@ The Finance Committee would like to give you some updates on our activities
 over the several months.
 
 
-# Cycle III Funding Results
+# Cycle 3 Funding Results
 
 We recently completed the proposal process for allocating the next round of
 funding for projects and other major expenses. This is the first time we have
 been able to allocate money from our NASA ROSES-2020 grant as well as our
-grant from the Moore foundation.
+grant from the Moore Foundation.
 
 A total of 22 proposals were received, of which 20 were allocated funds.
 Although our budget didn't quite stretch to supporting all projects at their
@@ -18,13 +18,13 @@ funding request, and — in many cases — substantially more.
 
 The full list of proposals funded in this process is available at [1]. Each
 proposal has been allocated a dedicated Finance Committee member who will guide
-project team through the process of getting started and claiming funds.
+the project team through the process of getting started and claiming funds.
 
 We're excited to be able to fund so many amazing projects! Thanks to those
 who submitted proposals and to everybody who took part in the discussion and
 voting process, and many congratulations to the successful project teams!
 
-The Finance Committee welcomes feedback on the funding process. Please feel
+Finally, the Finance Committee welcomes feedback on the funding process. Please feel
 free to reach out to us — see the contact details below — with your thoughts
 and suggestions for how it might be improved in the future.
 
@@ -39,7 +39,7 @@ Project's funds are being spent, check out the “finance” label in the
 astropy-project issue tracker [2].
 
 For previous funding rounds, we've used a single issue to keep track of all
-the various projects [3]. During Cycle III, we plan to use a single issue per
+the various projects [3]. During Cycle 3, we plan to use a single issue per
 project; watch out for these appearing over the next few days.
 
 [2] https://github.com/astropy/astropy-project/labels/finance%20%3Amoneybag%3A
@@ -69,7 +69,7 @@ As always, don't hesitate to reach out if you have questions.
 
 # Applying for Funding
 
-Although the Cycle III proposal process has now been completed, it's still
+Although the Cycle 3 proposal process has now been completed, it's still
 possible to apply to the Finance Committee for funding. We welcome requests
 following the guidelines at [6].
 
@@ -81,7 +81,7 @@ following the guidelines at [6].
 You can learn more about the Finance Committee's business and how you can get
 in touch in the astropy-project repository [7]. In particular, you can keep
 track of what we're working on by following our running notes [8], or reach
-out to us on Slack (#finance-committee), by filing a GitHub issue, or by mail
+out to us on Slack (#finance-committee), by filing a GitHub issue, or by e-mail
 to finance@astropy.org. We'd love to hear from you!
 
 [7] https://github.com/astropy/astropy-project/tree/main/finance

--- a/finance/community-updates/2022-10.txt
+++ b/finance/community-updates/2022-10.txt
@@ -24,8 +24,8 @@ We're excited to be able to fund so many amazing projects! Thanks to those
 who submitted proposals and to everybody who took part in the discussion and
 voting process, and many congratulations to the successful project teams!
 
-Finally, the Finance Committee welcomes feedback on the funding process. Please feel
-free to reach out to us — see the contact details below — with your thoughts
+Finally, the Finance Committee welcomes feedback on the funding process. Please
+feel free to reach out to us — see the contact details below — with your thoughts
 and suggestions for how it might be improved in the future.
 
 [1] https://github.com/astropy/astropy-project/pulls?q=label%3A%22funding-approved+💵%22+label%3A%22cycle+3%EF%B8%8F⃣%22+type%3Apr
@@ -33,10 +33,10 @@ and suggestions for how it might be improved in the future.
 
 # Keeping Track of Work in Progress
 
-The Finance Committee uses GitHub issues to discuss and track the progress of the various funded
-activities. If you would like to know where the
-Project's funds are being spent, check out the “finance” label in the
-astropy-project issue tracker [2].
+The Finance Committee uses GitHub issues to discuss and track the progress of
+the various funded activities. If you would like to know where the Project's
+funds are being spent, check out the “finance” label in the astropy-project
+issue tracker [2].
 
 For previous funding rounds, we've used a single issue to keep track of all
 the various projects [3]. During Cycle 3, we plan to use a single issue per
@@ -51,7 +51,7 @@ project; watch out for these appearing over the next few days.
 Over the spring and summer of this year, NumFOCUS — the organization that
 manages our accounts — switched to using Open Collective [4] for handling
 budgeting and invoicing. This new system is a substantial step forward — it's
-easier to use and more transparent than its predecessor.
+easier to use and more transparent than “Rocket”, its predecessor, was.
 
 All invoices must now be submitted through Open Collective. This process is
 straightforward, but it is important that you know which of our various
@@ -70,8 +70,8 @@ As always, don't hesitate to reach out if you have questions.
 # Applying for Funding
 
 Although the Cycle 3 proposal process has now been completed, it's still
-possible to apply to the Finance Committee for funding. We welcome requests at any time
-following the guidelines at [6].
+possible to apply to the Finance Committee for funding. We welcome requests
+at any time following the guidelines at [6].
 
 [6] https://github.com/astropy/astropy-project/blob/main/finance/process/request-funding.md
 

--- a/finance/community-updates/2022-10.txt
+++ b/finance/community-updates/2022-10.txt
@@ -1,7 +1,7 @@
 Dear Astropy Community,
 
 The Finance Committee would like to give you some updates on our activities
-over the several months.
+over the last several months.
 
 
 # Cycle 3 Funding Results

--- a/finance/community-updates/2022-10.txt
+++ b/finance/community-updates/2022-10.txt
@@ -17,7 +17,7 @@ full requested level, every approved proposal receives at least their minimum
 funding request, and — in many cases — substantially more.
 
 The full list of proposals funded in this process is available at [1]. Each
-proposal will be allocated a dedicated Finance Committee member who will guide
+proposal has been allocated a dedicated Finance Committee member who will guide
 project team through the process of getting started and claiming funds.
 
 We're excited to be able to fund so many amazing projects! Thanks to those

--- a/finance/community-updates/2022-10.txt
+++ b/finance/community-updates/2022-10.txt
@@ -1,0 +1,94 @@
+Dear Astropy Community,
+
+The Finance Committee would like to give you some updates on our activities
+over the several months.
+
+
+# Cycle III Funding Results
+
+We recently completed the proposal process for allocating the next round of
+funding for projects and other major expenses. This is the first time we have
+been able to allocate money from our NASA ROSES-2020 grant as well as our
+grant from the Moore foundation.
+
+A total of 22 proposals were received, of which 20 were allocated funds.
+Although our budget didn't quite stretch to supporting all projects at their
+full requested level, every approved proposal receives at least their minimum
+funding request, and — in many cases — substantially more.
+
+The full list of proposals funded in this process is availble at [1]. Each
+proposal will be allocated a dedicated Finance Committee member who will guide
+project team through the process of getting started and claiming funds.
+
+We're excited to be able to fund so many amazing projects! Thanks to those
+who submitted proposals and to everybody who took part in the discussion and
+voting process, and many congratulations to the successful project teams!
+
+The Finance Committee welcomes feedback on the funding process. Please feel
+free to reach out to us — see the contact details below — with your thoughts
+and suggestions for how it might be improved in the future.
+
+[1] https://github.com/astropy/astropy-project/issues?q=label%3A%22funding-approved+💵%22+label%3A%22cycle3%22+
+
+
+# Keeping Track of Work in Progress
+
+The Finance Committee uses GitHub issues to keep track of all the various ways
+in which we are allocating funds. If you would like to know where the
+Project's funds are being spent, check out the “finance” label in the
+astropy-project issue tracker [2].
+
+For previous funding rounds, we've used a single issue to keep track of all
+the various projects [3]. During Cycle III, we plan to use a single issue per
+project; watch out for these appearing over the next few days.
+
+[2] https://github.com/astropy/astropy-project/labels/finance%20%3Amoneybag%3A
+[3] https://github.com/astropy/astropy-project/issues/199/
+
+
+# Open Collective
+
+Over the spring and summer of this year, NumFOCUS — the organization that
+manages our accounts — switched to using Open Collective [4] for handling
+budgeting and invoicing. This new system is a substantial step forward — it's
+easier to use and more transparent than its predecessor.
+
+All invoices must now be submitted through Open Collective. This process is
+straightforward, but it is important that you know which of our various
+funding lines (or “projects” in Open Collective's jargon) you should submit
+your expense to (NASA, Moore, etc). If you aren't sure, reach out to the
+Finance Committee (details below) to check. When you know which project to
+use, head over to the Astropy area on Open Collective [5], select the right
+project, and then hit “submit expense”.
+
+As always, don't hesitate to reach out if you have questions.
+
+[4] https://opencollective.com
+[5] https://opencollective.com/astropy
+
+
+# Applying for Funding
+
+Although the Cycle III proposal process has now been completed, it's still
+possible to apply to the Finance Committee for funding. We welcome requests
+following the guidelines at [6].
+
+[6] https://github.com/astropy/astropy-project/blob/main/finance/process/request-funding.md
+
+
+# Finance Committee Contacts
+
+You can learn more about the Finance Committee's business and how you can get
+in touch in the astropy-project repository [7]. In particular, you can keep
+track of what we're working on by following our running notes [8], or reach
+out to us on Slack (#finance-committee), by filing a GitHub issue, or by mail
+to finance@astropy.org. We'd love to hear from you!
+
+[7] https://github.com/astropy/astropy-project/tree/main/finance
+[8] https://docs.google.com/document/d/1OpSEtJC0jQINTB-YNexxgnHX7-J6HRSkiPKYWBSCOfg/edit?usp=sharing
+
+Cheers,
+
+John
+on behalf of the Astropy Finance Committee
+

--- a/finance/community-updates/2022-10.txt
+++ b/finance/community-updates/2022-10.txt
@@ -28,7 +28,7 @@ The Finance Committee welcomes feedback on the funding process. Please feel
 free to reach out to us — see the contact details below — with your thoughts
 and suggestions for how it might be improved in the future.
 
-[1] https://github.com/astropy/astropy-project/issues?q=label%3A%22funding-approved+💵%22+label%3A%22cycle3%22+
+[1] https://github.com/astropy/astropy-project/pulls?q=label%3A%22funding-approved+💵%22+label%3A%22cycle+3%EF%B8%8F⃣%22+type%3Apr
 
 
 # Keeping Track of Work in Progress

--- a/finance/community-updates/2022-10.txt
+++ b/finance/community-updates/2022-10.txt
@@ -70,7 +70,7 @@ As always, don't hesitate to reach out if you have questions.
 # Applying for Funding
 
 Although the Cycle 3 proposal process has now been completed, it's still
-possible to apply to the Finance Committee for funding. We welcome requests
+possible to apply to the Finance Committee for funding. We welcome requests at any time
 following the guidelines at [6].
 
 [6] https://github.com/astropy/astropy-project/blob/main/finance/process/request-funding.md

--- a/finance/community-updates/2022-10.txt
+++ b/finance/community-updates/2022-10.txt
@@ -33,8 +33,8 @@ and suggestions for how it might be improved in the future.
 
 # Keeping Track of Work in Progress
 
-The Finance Committee uses GitHub issues to keep track of all the various ways
-in which we are allocating funds. If you would like to know where the
+The Finance Committee uses GitHub issues to discuss and track the progress of the various funded
+activities. If you would like to know where the
 Project's funds are being spent, check out the “finance” label in the
 astropy-project issue tracker [2].
 

--- a/finance/community-updates/2022-10.txt
+++ b/finance/community-updates/2022-10.txt
@@ -16,7 +16,7 @@ Although our budget didn't quite stretch to supporting all projects at their
 full requested level, every approved proposal receives at least their minimum
 funding request, and — in many cases — substantially more.
 
-The full list of proposals funded in this process is availble at [1]. Each
+The full list of proposals funded in this process is available at [1]. Each
 proposal will be allocated a dedicated Finance Committee member who will guide
 project team through the process of getting started and claiming funds.
 


### PR DESCRIPTION
Per the list in the running notes, this update should cover:

- [x] Travel funding is available. Reach out to finance if you want to travel for Astropy’s benefit. 
- [x] Switch to open collective for submitting invoices.
- [x] SOSS debrief - lessons learned. - Erik and Adrian to draft.
- [x] Dunlap update? 
- [x] Highlight the funding issues, call attention to the finance label in project issue tracker.
- [x] Link to the running notes.
- [x] Announce results of Cycle 3 processes.
