### PR TITLE
Cycle 4: Specreduce and other spectrocopy work (Pickering)

### DIFF
--- a/finance/proposal-calls/cycle4/pickering_specreduce.md
+++ b/finance/proposal-calls/cycle4/pickering_specreduce.md
@@ -20,11 +20,9 @@ Some specific areas that we expect to tackle during the coming cycle include:
 * Expand outreach to and collaboration with EPRV spectroscopy community
 
 ### Approximate Budget
-Currency: US $53000
+Currency: US $46000
 
 - Salary: US $46000 ($23000/yr based on 4 hours/week for 48 weeks at current contracted rate of $120/hour)
-- Travel: US $7000 ($2500 SPIE 2024 to present paper on specreduce; $2500 ADASS 2024; $2000 ADASS 2025)
-
 
 ### Period of Performance
 2 years starting May 2024

--- a/finance/proposal-calls/cycle4/pickering_specreduce.md
+++ b/finance/proposal-calls/cycle4/pickering_specreduce.md
@@ -1,0 +1,30 @@
+### Title
+
+Development, Coordination, and Community Engagement involving specreduce and other spectroscopy-related tools by Timothy Pickering
+
+### Project Team
+Timothy Pickering
+
+### Project Description
+This is to continue specreduce development and outreach that was carried out in previous cycles.
+
+### Project / Work
+Some specific areas that we expect to tackle during the coming cycle include:
+
+* Generic manual wavelength calibration classes (i.e. analogs to "identify" from iraf, should use previous specreduce tools for this where possible)
+* Automatic wavelength calibration using existing templates (i.e. "reidentify", or "full template" from pypeit)
+* Improved WCS tools and expanded examples of their use within spectroscopic contexts
+* Support for / workflows with multi-object spectrographs
+* Support for fiber-based spectrographs, both single and multi-object as well as fiber-based IFUs
+* Continued/expanded outreach to observatories and software projects (e.g. PypeIt) to improve integration and workflows
+* Expand outreach to and collaboration with EPRV spectroscopy community
+
+### Approximate Budget
+Currency: US $53000
+
+- Salary: US $46000 ($23000/yr based on 4 hours/week for 48 weeks at current contracted rate of $120/hour)
+- Travel: US $7000 ($2500 SPIE 2024 to present paper on specreduce; $2500 ADASS 2024; $2000 ADASS 2025)
+
+
+### Period of Performance
+2 years starting May 2024


### PR DESCRIPTION
Proposal to continue on with specreduce and other astropy-related spectroscopy efforts.