### PR TITLE
Moving Astropy Compilation Team Docs onto GitHub

### DIFF
--- a/policies/README.md
+++ b/policies/README.md
@@ -11,9 +11,9 @@ This directory holds documents of policies for the Astropy Project.  For example
   - Bi-weekly closed meetings on Project calendar
   - Private slack channel
 - External Communication
-  - Email: coordinators@astropy.org
+  - Email: coordinators at astropy dot org
   - Github team [@astropy/coordinators](https://github.com/orgs/astropy/teams/coordinators)
-  - Quarterly updates to email lists.
+  - "State of Astropy" presentation at Astropy Coordination Meetings.
 
 ### Finance Committee
 - Policies
@@ -25,8 +25,9 @@ This directory holds documents of policies for the Astropy Project.  For example
   - Weekly closed meetings on Project calendar
   - DM group
 - External Communication
-  - Email: finance@astropy.org
+  - Email: finance at astropy dot org
   - #finance-committee Slack channel
+  - Private Slack channel for confidential items
   - Quarterly-ish updates to email lists.
 
 ### Learn Team
@@ -36,12 +37,9 @@ This directory holds documents of policies for the Astropy Project.  For example
 
 ### Infrastructure/DevOps Team
 - Policies: No formal policies. 
-- Records: [Running Notes](https://docs.google.com/document/d/15JSFh3OMF9Iz6ov3q_xxGO_BL8hRnuse4IMUrqEIvcg/edit)
+- Records: Archival [Running Notes](https://docs.google.com/document/d/15JSFh3OMF9Iz6ov3q_xxGO_BL8hRnuse4IMUrqEIvcg/edit)
 - Communication (all open):
-  - Regular open meetings on Project calendar
   - #infrastructure Slack channel
   - Github team: [@astropy/devops-maintainers](https://github.com/orgs/astropy/teams/devops-maintainers) 
     (this group only contains a subset of those who attend the tag-ups)
   - Open issues/PRs on relevant Astropy org GitHub repos and tag @astropy/devops-maintainers.
-
-

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,1 +1,47 @@
+# Astropy Policies
+
 This directory holds documents of policies for the Astropy Project.  For example, rules for who gets certain rights or permissions and what the expectations are if they do.
+
+## Committee/Team Specifics
+
+### Coordination Committee
+- Policies: [CoCo Operating Policies](coco-operating-policies.md)
+- Records: [Running Notes](https://docs.google.com/document/d/1t7gEE6gIgNUCyObQFq3aYFMcOh4V4m27CNrxBGYwQuw/edit)
+- Internal Communication
+  - Bi-weekly closed meetings on Project calendar
+  - Private slack channel
+- External Communication
+  - Email: coordinators@astropy.org
+  - Github team [@astropy/coordinators](https://github.com/orgs/astropy/teams/coordinators)
+  - Quarterly updates to email lists.
+
+### Finance Committee
+- Policies
+  - [Policies](../finance/process/policies.rst)
+  - [Procedures](../finance/process/procedures.rst)
+  - [Process documents](../finance/process)
+- Records: [Running Notes](https://docs.google.com/document/d/1OpSEtJC0jQINTB-YNexxgnHX7-J6HRSkiPKYWBSCOfg/edit#heading=h.sbqrluwi12sn)
+- Internal Communication
+  - Weekly closed meetings on Project calendar
+  - DM group
+- External Communication
+  - Email: finance@astropy.org
+  - #finance-committee Slack channel
+  - Quarterly-ish updates to email lists.
+
+### Learn Team
+- Policies: No formal policies.
+- Records: Archival [Running Notes](https://docs.google.com/document/d/1T6FL0_XhnMEtI1Qq_KNZZzD0HNuVR3wHhhDYj9d21z0/edit)
+- Communication (all open): #learn channel on Astropy Slack
+
+### Infrastructure/DevOps Team
+- Policies: No formal policies. 
+- Records: [Running Notes](https://docs.google.com/document/d/15JSFh3OMF9Iz6ov3q_xxGO_BL8hRnuse4IMUrqEIvcg/edit)
+- Communication (all open):
+  - Regular open meetings on Project calendar
+  - #infrastructure Slack channel
+  - Github team: [@astropy/devops-maintainers](https://github.com/orgs/astropy/teams/devops-maintainers) 
+    (this group only contains a subset of those who attend the tag-ups)
+  - Open issues/PRs on relevant Astropy org GitHub repos and tag @astropy/devops-maintainers.
+
+


### PR DESCRIPTION
This PR moves [Compilation of the Team Docs of the Astropy Project](https://docs.google.com/document/d/19Hj8v4yP2q5Hb5G4KMLdDcjf6yQEH_9z104d0O6C34g/edit) (permission required) into GitHub. 