### PR TITLE
Allow any Voting Member to initiate nomination process for adding new role members

### DIFF
--- a/messages/role_annoucement.md
+++ b/messages/role_annoucement.md
@@ -1,14 +1,14 @@
 Text for announcement to astropy-dev mailing list
 
-The CoCo proposes to [select as appropriate]
+We/I propose to [select as appropriate]
 - add/remove the following roles to the list of roles on the Astropy project:
 - add/remove the following people for role XXX in the Astropy project:
 
-See https://www.astropy.org/team for a list of current roles. Following APE 0 [1] we leave a two week long comment period for this proposal where you can comment publicly on the PR [2] or privately to the CoCo (coordinators@astropy.org or DM one of them on Slack). If there are no objections after two weeks, the CoCo will merge the PR [3].
+See https://www.astropy.org/team for a list of current roles. Following APE 0 [1] we leave a two week long comment period for this proposal where you can comment publicly on the PR [2] or privately to the CoCo (coordinators@astropy.org or DM one of them on Slack). If there are no objections after two weeks, the CoCo shall merge the PR [3].
 
 Sincerely,
 Name
-(for the CoCo)
+(for the Astropy Project)
 
 [1] https://github.com/astropy/astropy-APEs/blob/main/APE0.rst
 [2] LINK TO PR HERE

--- a/policies/adding-new-role-members.md
+++ b/policies/adding-new-role-members.md
@@ -13,9 +13,10 @@ which is highlighted in the process below.
 
 The process is:
 
-1. A voting member or maintainer in a related role sends a message to the person nominated
-   (with the Coordination Committee in the cc), making sure they understand the role, 
-   its responsibilities, and confirming that the nominee agrees. 
+1. A voting member or maintainer in a related role, after consulting with other members in
+   related roles, sends a message to the person nominated (with the Coordination Committee
+   in the cc), making sure they understand the role, its responsibilities, and confirming
+   that the nominee agrees.
    ([suggested text](https://github.com/astropy/astropy-project/blob/main/messages/maintainer_access.md)).
 2. The nominee should also be asked (generally but not necessarily in the
    message above) to confirm they agree the Code of Conduct, and that they are

--- a/policies/adding-new-role-members.md
+++ b/policies/adding-new-role-members.md
@@ -13,8 +13,9 @@ which is highlighted in the process below.
 
 The process is:
 
-1. A voting member or maintainer in a related role sends a message to the person nominated (with the CoCo in the cc), making sure they
-   understand the role, its responsibilities, and confirming that the nominee agrees. 
+1. A voting member or maintainer in a related role sends a message to the person nominated
+   (with the Coordination Committee in the cc), making sure they understand the role, 
+   its responsibilities, and confirming that the nominee agrees. 
    ([suggested text](https://github.com/astropy/astropy-project/blob/main/messages/maintainer_access.md)).
 2. The nominee should also be asked (generally but not necessarily in the
    message above) to confirm they agree the Code of Conduct, and that they are

--- a/policies/adding-new-role-members.md
+++ b/policies/adding-new-role-members.md
@@ -13,7 +13,7 @@ which is highlighted in the process below.
 
 The process is:
 
-1. A voting member sends a message to the person nominated, making sure they
+1. A voting member or maintainer in a related role sends a message to the person nominated (with the CoCo in the cc), making sure they
    understand the role, its responsibilities, and confirming that the nominee agrees. 
    ([suggested text](https://github.com/astropy/astropy-project/blob/main/messages/maintainer_access.md)).
 2. The nominee should also be asked (generally but not necessarily in the

--- a/policies/adding-new-role-members.md
+++ b/policies/adding-new-role-members.md
@@ -13,9 +13,8 @@ which is highlighted in the process below.
 
 The process is:
 
-1. A Coordination Committee member sends a message to the person
-   nominated, making sure they understand the role, its responsibilities, and
-   confirming that the nominee agrees. 
+1. A voting member sends a message to the person nominated, making sure they
+   understand the role, its responsibilities, and confirming that the nominee agrees. 
    ([suggested text](https://github.com/astropy/astropy-project/blob/main/messages/maintainer_access.md)).
 2. The nominee should also be asked (generally but not necessarily in the
    message above) to confirm they agree the Code of Conduct, and that they are
@@ -23,7 +22,10 @@ The process is:
 3. If the nominee does not accept, the process stops here.
 4. If the nominee does accept, a PR is made adding the member to the roles page as a 
    place for public comment.
-5. A message linking to the PR is sent to the community by a Coordination Committee member, starting a two-week clock on    the feedback period [as required by APE0](https://github.com/astropy/astropy-APEs/blob/main/APE0.rst#responsibilities-and-authority).
+5. A message linking to the PR is sent to the community
+   ([suggested text](https://github.com/astropy/astropy-project/blob/main/messages/role_annoucement.md)),
+   starting a two-week clock on the feedback period
+   [as required by APE0](https://github.com/astropy/astropy-APEs/blob/main/APE0.rst#responsibilities-and-authority).
 6. Once the two week period has elapsed, the Coordination Committee makes a
    final decision based on any feedback.
 7. If the appointment is confirmed, the PR from Step 4 is merged and the nominee is added to the [roles page](https://www.astropy.org/team).


### PR DESCRIPTION
In response to https://github.com/astropy/astropy-project/issues/435#issuecomment-2239194529 this PR is modifying the nomination policy to permit any Voting Member to invite a nominee, open a PR and send the announcement to start the voting period, i.e. the first 5 steps described in the nomination process. It also changes message templates accordingly.

In the present form, this does not specifically mandate any confirmation from the CoCo in this phase, though this could still be added – specifically, if `maintainer_access.md` should still mention "acceptance [of the nomination] by CoCo" this should indeed be confirmed before step 1.