### PR TITLE
Add TOC to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,11 @@
 
 Documents and policies regarding the Astropy Project as a whole.  *Drafts* of policies under consideration go into the `drafts` directory.  Other directories can be created as needed to maintain organization, but as a general guideline a new directory should not be created unless it contains (or will contain) at least 3 files.
 
-Additionally, the issue tracker will be used to discuss larger Project-wide issues; i.e., those that are not particular to a specific pacakge or other repository.
+* `affiliated`: Astropy Affiliated Package review policies and guidelines.
+* `finance`: Astropy Finance Committee policies, proposals, and other documents.
+* `infrastructure`: Astropy infrastructure documents.
+* `messages`: Templates for communications related to current active policies.
+* `policies`: Astropy Project policies, including but not limited to roles, elections, and permissions.
+* `roadmap`: Astropy Project roadmap, to be updated annually at the Astropy Coordination Meeting.
 
+Additionally, the issue tracker will be used to discuss larger Project-wide issues; i.e., those that are not particular to a specific pacakge or other repository.


### PR DESCRIPTION
So people know what is in the folders without having to clicking through everything. I did not include things I want to be removed in:

* #443 
* #444