### PR TITLE
Fixing documentation and message template for adding new members

### DIFF
--- a/messages/maintainer_access.md
+++ b/messages/maintainer_access.md
@@ -1,14 +1,15 @@
 Hello {NAME},
 
-You have been nominated as {role} and the Coordinating Committee has enthusiastically accepted this nomination! We would be thrilled if you are able to accept this nomination. {More context might be necessary for some people - fill it in here}
+You have been nominated as {role} and {members of the Astropy core team|the Coordinating Committee} enthusiastically support this nomination!  We would be thrilled if you are able to accept this nomination.  {More context might be necessary for some people - fill it in here}
 
-In case you are not familiar with the role, maintainers are the people who keep a package or sub-package working. In particular, they review and merge PRs, keep track of what's going on and organize ideas for future development (see https://www.astropy.org/team.html#Subpackage_maintainer for details). In practice this means a fair amount of community interaction when reviewing PRs and related discussion.  As a general guideline, if you have any uncertainty or if there is extended debate about merging a PR, seek consensus from other maintainers in the Project.  If necessary, you should also free to reach out to the Coordination Committee (by @-mention on github or via coordinators@astropy.org), as the Coordination Committee has the authority to make decisions when consensus cannot be achieved.
+In case you are not familiar with the role, maintainers are the people who keep a package or sub-package working.  In particular, they review and merge PRs, keep track of what's going on and organize ideas for future development (see https://www.astropy.org/team.html#Subpackage_maintainer for details).  In practice this means a fair amount of community interaction when reviewing PRs and related discussion.  As a general guideline, if you have any uncertainty or if there is extended debate about merging a PR, seek consensus from other maintainers in the Project.  If necessary, you should also feel free to reach out to the Coordination Committee (by @-mention on github or via coordinators@astropy.org), as the Coordination Committee has the authority to make decisions when consensus cannot be achieved.
 
 If you would like to accept this nomination, we ask that you familiarize yourself with the following Project guidelines:
 
-* [Developer guidelines for Astropy](https://docs.astropy.org/en/latest/#developer-documentation)
-* [Basic development workflow](https://docs.astropy.org/en/latest/development/workflow/development_workflow.html)
-* [Guidelines on when to squash or rebase](https://docs.astropy.org/en/latest/development/when_to_rebase.html)
+* [Developer guidelines for Astropy](https://docs.astropy.org/en/latest/index_dev.html)
+* [Basic development workflow](https://docs.astropy.org/en/latest/development/quickstart.html)
+* [Setting up automated code style and linting checks](https://docs.astropy.org/en/latest/development/development_details.html#pre-commit)
+* [Guidelines on when to squash or rebase](https://docs.astropy.org/en/latest/development/development_details.html#rebase)
 * [Astropy Project Code of Conduct](https://www.astropy.org/code_of_conduct.html)
 * [GitHub two-factor authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)
 

--- a/policies/adding-new-role-members.md
+++ b/policies/adding-new-role-members.md
@@ -19,7 +19,7 @@ The process is:
    that the nominee agrees.
    ([suggested text](https://github.com/astropy/astropy-project/blob/main/messages/maintainer_access.md)).
 2. The nominee should also be asked (generally but not necessarily in the
-   message above) to confirm they agree the Code of Conduct, and that they are
+   message above) to confirm they agree to abide by the Code of Conduct, and that they are
    aware of guidelines relevant to the role.
 3. If the nominee does not accept, the process stops here.
 4. If the nominee does accept, a PR is made adding the member to the roles page as a 


### PR DESCRIPTION
Adjusting the wording in maintainer letter that has not been adapted to the procedure from #436; also fixing a (I think) grammar mistake in the policies document.
Also several of the documentation links in the letter template have been broken following astropy/astropy#16561 – thanks for reporting, @neutrinoceros! Not all of them have exact equivalents in the restructured docs, so I tried to substitute the most useful counterparts.