### PR TITLE
Added section about closing formatting PRs without review

### DIFF
--- a/policies/pull-request-review-and-merge.md
+++ b/policies/pull-request-review-and-merge.md
@@ -39,6 +39,16 @@ follows these guidelines.
 After successful review, the maintainer(s) will formally approve the pull
 request.
 
+While we welcome pull requests for anyone, pull requests that are purely related
+to code formatting or restructuring without change in functionality (including,
+but not limited to, the use of automated tools) may in some cases be closed
+without review, since these kinds of changes can cause unecessary conflicts with
+other pull requests, or may not line up with the coding style or wishes of the
+current maintainer(s). In these cases, it should be made clear to the contributor
+that we still value their interest in contributing to the project, but point
+them to this policy to explain that we cannot always accept these kinds of
+changes.
+
 ### Additional Checks
 
 Additional checks will be performed to verify that there are no other issues


### PR DESCRIPTION
This is a draft, to try and address the concept brought up during the coordination meeting that we should be able to close unsolicited formatting/restructuring PRs that don't have a clear benefit. Happy to iterate on the wording!