### PR TITLE
Cycle5: X-ray spectroscopy and io.ascii fixes

### DIFF
--- a/finance/proposal-calls/cycle5/hamogu.md
+++ b/finance/proposal-calls/cycle5/hamogu.md
@@ -51,7 +51,7 @@ Bring X-ray spectroscopy to `specutils` and `astropy.modelling`. Moritz is one o
 ### Approximate Budget
 Budget breakdown (nominal):
 
-- $28,000 for 10% of my time per year
+- $30,000 for 10% of my time per year
 
 (Since this will be a sub-award to MIT, my salary is fixed by MIT and the overhead rate is fixed by agreement between MIT and the US government for NASA grants. We can choose the amount of time funded, but not the hourly rate.)
 


### PR DESCRIPTION
Address (by fixing or closing) open issues in astropy.io.ascii, astropy affiliate editor, organization of dev-telecons, development and review of other astropy and specutils code.

Relations to cycle 4 request: In the discussion on Moritz cycle 4 request the finance committee requested a 2-3 year budget and a matching scope; this proposal is to execute year 2 of that longer-term plan. Work has started but delayed transfer of the funding from NumFOCUS to MIT and medical leave for Moritz in the fall of 2025 mean that only a fraction of the originally proposed work has been done so far (but more will be done before the end of the year)