### PR TITLE
Update CoCo transition checklist on transferring Gsuite ownership

### DIFF
--- a/policies/coco-transition-checklist.md
+++ b/policies/coco-transition-checklist.md
@@ -11,6 +11,7 @@ as needed.
     - Organization-wide ownership
     - Team: [coordinators](https://github.com/orgs/astropy/teams/coordinators)
 - [ ] Passwords access
+      - Should be invited by a current Password admin
 - [ ] Coordinators mailing list(s)
     - Privacy policy regarding Coordinators email list
     - Add to coordinators Google group


### PR DESCRIPTION
Adding instructions on granting Gsuite ownership rights and astropy.org accounts.

Hope this makes sense where it is placed now between ownerships of the Google Shared Drive and the various mailing lists (I really don't understand any of the details how these are handled by Google).