### PR TITLE
AI Policy

### DIFF
--- a/policies/ai-policy.md
+++ b/policies/ai-policy.md
@@ -1,0 +1,11 @@
+Usage of Generative AI
+
+Astropy maintainers welcome contributions, including those developed with the assistance of generative AI tools. However, the use of such tools does not change our expectations for contributor responsibility, engagement, or code quality. The following apply to all contributions.
+
+Human ownership and accountability
+Contributors are responsible for all submitted content, regardless of whether generative AI tools were used.
+Contributors must be able to explain all changes during review.
+
+Authentic engagement. The pull request process is collaborative and iterative. Contributors are expected to actively engage with reviewer feedback.
+
+Consistency with Astropy conventions and existing style. In the context of Generative AI, this particularly means conveying information (comments, documentation, etc) in a style the Astropy user community will understand.

--- a/policies/ai-policy.md
+++ b/policies/ai-policy.md
@@ -4,6 +4,10 @@ Astropy maintainers welcome contributions, including those developed with the as
 
 1. Human ownership and accountability
     1. Contributors are responsible for all submitted content, regardless of whether generative AI tools were used.
-    1. Contributors must be able to explain all changes during review.
-2. Authentic engagement. The pull request process is collaborative and iterative. Contributors are expected to actively engage with reviewer feedback.
-3. Consistency with Astropy conventions and existing style. In the context of Generative AI, this particularly means conveying information (comments, documentation, etc) in a style the Astropy user community will understand.
+    2. Contributors must be able to explain all changes during review.
+2. Authentic engagement. The pull request process is collaborative and iterative. Contributors are expected to actively engage with reviewer feedback themselves. Copying and pasting replies to / from a generative AI tool does not count as engaging with the reviewer; contributors are expected to understand the changes they are proposing, not act as message courier for a third party. 
+3. Consistency with Astropy conventions and existing style. In the context of Generative AI, this particularly means conveying information (comments, documentation, etc) in a style the Astropy user community will understand, and that is appropriate and to the point.
+
+> [!NOTE]
+> This policy is in part inspired by the scikit-learn ["Automated Contributions Policy"](https://scikit-learn.org/stable/developers/contributing.html#automated-contributions-policy), which has additional details that may be useful in interpreting this policy.
+

--- a/policies/ai-policy.md
+++ b/policies/ai-policy.md
@@ -1,11 +1,9 @@
-Usage of Generative AI
+# Usage of Generative AI
 
 Astropy maintainers welcome contributions, including those developed with the assistance of generative AI tools. However, the use of such tools does not change our expectations for contributor responsibility, engagement, or code quality. The following apply to all contributions.
 
-Human ownership and accountability
-Contributors are responsible for all submitted content, regardless of whether generative AI tools were used.
-Contributors must be able to explain all changes during review.
-
-Authentic engagement. The pull request process is collaborative and iterative. Contributors are expected to actively engage with reviewer feedback.
-
-Consistency with Astropy conventions and existing style. In the context of Generative AI, this particularly means conveying information (comments, documentation, etc) in a style the Astropy user community will understand.
+1. Human ownership and accountability
+    1. Contributors are responsible for all submitted content, regardless of whether generative AI tools were used.
+    1. Contributors must be able to explain all changes during review.
+2. Authentic engagement. The pull request process is collaborative and iterative. Contributors are expected to actively engage with reviewer feedback.
+3. Consistency with Astropy conventions and existing style. In the context of Generative AI, this particularly means conveying information (comments, documentation, etc) in a style the Astropy user community will understand.

--- a/policies/ai-policy.md
+++ b/policies/ai-policy.md
@@ -5,8 +5,9 @@ Astropy maintainers welcome contributions, including those developed with the as
 1. Human ownership and accountability
     1. Contributors are responsible for all submitted content, regardless of whether generative AI tools were used.
     2. Contributors must be able to explain all changes during review.
+    3. Contributers are responsible for ensuring all submitted code complies with Astropy's licensing, regardless of whether generative AI tools were used.
 2. Authentic engagement. The pull request process is collaborative and iterative. Contributors are expected to actively engage with reviewer feedback themselves. Copying and pasting replies to / from a generative AI tool does not count as engaging with the reviewer; contributors are expected to understand the changes they are proposing, not act as message courier for a third party. 
-3. Consistency with Astropy conventions and existing style. In the context of Generative AI, this particularly means conveying information (comments, documentation, etc) in a style the Astropy user community will understand, and that is appropriate and to the point.
+3. Consistency with Astropy conventions and existing style. In the context of Generative AI, this particularly means conveying information (comments, documentation, etc) in a style the Astropy community uses, and that is appropriate and to the point.
 
 > [!NOTE]
 > This policy is in part inspired by the scikit-learn ["Automated Contributions Policy"](https://scikit-learn.org/stable/developers/contributing.html#automated-contributions-policy), which has additional details that may be useful in interpreting this policy.


### PR DESCRIPTION
Adding an AI policy document to Astropy's policies.

This policy was drafted by the CoCo, making use the discussion to close https://github.com/astropy/astropy-project/issues/509

The comment period for this policy document is open now (9 February), and will run through 23 February.